### PR TITLE
PN-001: CMake Build & Install for client-next

### DIFF
--- a/client-next/package.json
+++ b/client-next/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/client-next/vite.config.ts
+++ b/client-next/vite.config.ts
@@ -4,6 +4,7 @@ import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 
 export default defineConfig({
+  base: './',
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -41,7 +41,7 @@ Critique phases are explicit gates — they prevent premature implementation and
 
 | PN | Title | Status | Effort | Requires | GitHub Issue |
 |----|-------|--------|--------|----------|-------------|
-| PN-001 | [Client-Next CMake Build & Install](PN-001-client-next-default.md) | 📋 INVESTIGATION | ~2h | None | [#1](https://github.com/dcat52/argos3-webviz/issues/1) |
+| PN-001 | [Client-Next CMake Build & Install](PN-001-client-next-default.md) | 🔵 IMPLEMENTATION | ~2h | None | [#1](https://github.com/dcat52/argos3-webviz/issues/1) |
 | PN-002 | [Delta Encoding Protocol](PN-002-delta-protocol.md) | 📋 INVESTIGATION | ~2h | PN-006 | [#2](https://github.com/dcat52/argos3-webviz/issues/2) |
 | PN-003 | [Seamless Record → Replay](PN-003-recorder-replay.md) | 📋 INVESTIGATION | ~4h | None | [#3](https://github.com/dcat52/argos3-webviz/issues/3) |
 | PN-004 | [Generic Data Visualization System](PN-004-viz-system.md) | 📋 INVESTIGATION | ~5.5h | None | [#4](https://github.com/dcat52/argos3-webviz/issues/4) |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,6 +109,39 @@ add_subdirectory(plugins)
 
 add_subdirectory(testing)
 
+#
+# Client-next web client (optional — requires Node.js/npm)
+#
+find_program(NPM_EXECUTABLE npm)
+
+if(NPM_EXECUTABLE)
+  set(CLIENT_NEXT_DIR "${CMAKE_SOURCE_DIR}/../client-next")
+  set(CLIENT_NEXT_DIST "${CLIENT_NEXT_DIR}/dist")
+  set(CLIENT_NEXT_STAMP "${CMAKE_BINARY_DIR}/client-next.stamp")
+
+  add_custom_command(
+    OUTPUT ${CLIENT_NEXT_STAMP}
+    COMMAND ${NPM_EXECUTABLE} ci --prefix ${CLIENT_NEXT_DIR}
+    COMMAND ${NPM_EXECUTABLE} run build --prefix ${CLIENT_NEXT_DIR}
+    COMMAND ${CMAKE_COMMAND} -E touch ${CLIENT_NEXT_STAMP}
+    WORKING_DIRECTORY ${CLIENT_NEXT_DIR}
+    COMMENT "Building client-next web client"
+    DEPENDS ${CLIENT_NEXT_DIR}/package.json ${CLIENT_NEXT_DIR}/package-lock.json
+  )
+
+  add_custom_target(client-next ALL DEPENDS ${CLIENT_NEXT_STAMP})
+
+  install(
+    DIRECTORY ${CLIENT_NEXT_DIST}/
+    DESTINATION share/argos3/plugins/simulator/visualizations/webviz/client
+  )
+
+  message(STATUS "client-next: npm found — web client will be built")
+else()
+  message(WARNING "npm not found — client-next will not be built. "
+                  "Install Node.js to build the web client.")
+endif()
+
 # Add Uninstall target
 add_custom_target(uninstall
   "${CMAKE_COMMAND}" -P "${CMAKE_SOURCE_DIR}/cmake/uninstall.cmake"


### PR DESCRIPTION
## Proposal

Closes #1

> **Stacked on #10 (PN-007).** Merge #10 first, then retarget this to `client-next`.

## Description

CMake build & install targets so client-next is built and distributed with the plugin.

- CMake custom target `client-next` runs `npm ci && npm run build`
- Stamp file: only rebuilds when package.json/package-lock.json change
- Install dist/ to `share/argos3/.../webviz/client`
- Graceful fallback when npm not found (warning, not error)
- Vite `base: './'` for relative asset paths in production
- `engines: node >= 18` in package.json

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Components Affected

- [x] Next client (`client-next/`)
- [x] Build system / CMake

## Checklist

- [x] Tests pass locally
- [x] Backwards compatible