### PR TITLE
PN-002: Delta Encoding Protocol

### DIFF
--- a/client-next/package.json
+++ b/client-next/package.json
@@ -20,7 +20,9 @@
     "mock:swarm": "tsx src/mock/server.ts swarm",
     "mock:mixed": "tsx src/mock/server.ts mixed",
     "mock:stress": "tsx src/mock/server.ts stress",
-    "mock:corridor": "tsx src/mock/server.ts corridor"
+    "mock:corridor": "tsx src/mock/server.ts corridor",
+    "mock:delta": "tsx src/mock/server.ts swarm --delta",
+    "mock:delta:stress": "tsx src/mock/server.ts stress --delta"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/client-next/src/mock/server.ts
+++ b/client-next/src/mock/server.ts
@@ -1,13 +1,19 @@
 /**
  * Mock WebSocket server for testing the client without ARGoS.
- * 
- * Run: npx tsx src/mock/server.ts [scene]
- * Scenes: empty, single, swarm, mixed, stress, corridor
+ *
+ * Run: npx tsx src/mock/server.ts [scene] [--delta]
+ * Scenes: empty, single, swarm, mixed, stress, corridor, stress_500, etc.
+ *
+ * --delta enables delta encoding: first message is schema, subsequent
+ * messages only include entities with changed fields.
  */
 import { WebSocketServer, WebSocket } from 'ws'
 import { scenes, type Scene } from './scenes'
 
-const sceneName = process.argv[2] || 'swarm'
+const args = process.argv.slice(2)
+const deltaFlag = args.includes('--delta')
+const sceneName = args.find(a => !a.startsWith('--')) || 'swarm'
+
 let currentScene = scenes[sceneName]
 if (!currentScene) {
   console.error(`Unknown scene: ${sceneName}`)
@@ -17,25 +23,101 @@ if (!currentScene) {
 
 const PORT = 3000
 const BROADCAST_HZ = 10
+const KEYFRAME_INTERVAL = 100
+
 const wss = new WebSocketServer({ port: PORT, host: '0.0.0.0' })
 
 let state = 'EXPERIMENT_INITIALIZED'
 let step = 0
 let running = false
 
+// Delta state
+let prevEntities: Record<string, Record<string, unknown>> = {}
+let schemaSent = false
+let stepsSinceKeyframe = 0
+
+// Per-client tracking for late joiners
+const clientNeedsSchema = new Set<WebSocket>()
+
+function entityToMap(entities: unknown[]): Record<string, Record<string, unknown>> {
+  const map: Record<string, Record<string, unknown>> = {}
+  for (const e of entities) {
+    const entity = e as Record<string, unknown>
+    map[entity.id as string] = entity
+  }
+  return map
+}
+
+function computeDelta(
+  current: Record<string, Record<string, unknown>>,
+  prev: Record<string, Record<string, unknown>>,
+): Record<string, Record<string, unknown>> {
+  const delta: Record<string, Record<string, unknown>> = {}
+  for (const [id, entity] of Object.entries(current)) {
+    const prevEntity = prev[id]
+    if (!prevEntity) {
+      delta[id] = entity // new entity — send full
+      continue
+    }
+    const changed: Record<string, unknown> = {}
+    for (const [key, val] of Object.entries(entity)) {
+      if (key === 'type' || key === 'id') continue
+      if (JSON.stringify(val) !== JSON.stringify(prevEntity[key])) {
+        changed[key] = val
+      }
+    }
+    if (Object.keys(changed).length > 0) {
+      delta[id] = changed
+    }
+  }
+  return delta
+}
+
+function buildMessage(entities: unknown[]): string {
+  const arena = currentScene.arena
+  const userData = { available_scenes: Object.keys(scenes), current_scene: Object.keys(scenes).find(k => scenes[k] === currentScene) }
+
+  if (!deltaFlag) {
+    return JSON.stringify({ type: 'broadcast', state, steps: step, timestamp: Date.now(), arena, entities, user_data: userData })
+  }
+
+  const currentMap = entityToMap(entities)
+
+  // Schema: first frame, keyframe interval, or new client needs it
+  if (!schemaSent || stepsSinceKeyframe >= KEYFRAME_INTERVAL) {
+    schemaSent = true
+    stepsSinceKeyframe = 0
+    prevEntities = currentMap
+    return JSON.stringify({ type: 'schema', state, steps: step, timestamp: Date.now(), arena, entities, user_data: userData })
+  }
+
+  // Delta
+  stepsSinceKeyframe++
+  const delta = computeDelta(currentMap, prevEntities)
+  prevEntities = currentMap
+  return JSON.stringify({ type: 'delta', state, steps: step, timestamp: Date.now(), arena, entities: delta, user_data: userData })
+}
+
 function broadcast() {
   const data = currentScene.generate(step)
-  const msg = JSON.stringify({
-    type: 'broadcast',
-    state,
-    steps: step,
-    timestamp: Date.now(),
-    arena: currentScene.arena,
-    entities: data,
-    user_data: { available_scenes: Object.keys(scenes), current_scene: Object.keys(scenes).find(k => scenes[k] === currentScene) },
-  })
+  const msg = buildMessage(data)
+
   wss.clients.forEach((ws) => {
-    if (ws.readyState === WebSocket.OPEN) ws.send(msg)
+    if (ws.readyState !== WebSocket.OPEN) return
+
+    // Late joiner: send schema instead of whatever the tick produced
+    if (deltaFlag && clientNeedsSchema.has(ws)) {
+      clientNeedsSchema.delete(ws)
+      const schema = JSON.stringify({
+        type: 'schema', state, steps: step, timestamp: Date.now(),
+        arena: currentScene.arena, entities: data,
+        user_data: { available_scenes: Object.keys(scenes), current_scene: Object.keys(scenes).find(k => scenes[k] === currentScene) },
+      })
+      ws.send(schema)
+      return
+    }
+
+    ws.send(msg)
   })
 }
 
@@ -57,7 +139,13 @@ setInterval(tick, 1000 / BROADCAST_HZ)
 
 wss.on('connection', (ws) => {
   console.log(`Client connected (${wss.clients.size} total)`)
-  broadcast() // send initial state
+
+  if (deltaFlag && schemaSent) {
+    // Late joiner — mark for schema on next tick
+    clientNeedsSchema.add(ws)
+  } else {
+    broadcast()
+  }
 
   ws.on('message', (raw) => {
     try {
@@ -84,18 +172,23 @@ wss.on('connection', (ws) => {
           state = 'EXPERIMENT_INITIALIZED'
           step = 0
           running = false
+          schemaSent = false
+          stepsSinceKeyframe = 0
+          prevEntities = {}
           break
         case 'terminate':
           state = 'EXPERIMENT_DONE'
           running = false
           break
         default:
-          // Custom command: switch scene
           if (cmd.command === 'switchScene' && cmd.scene && scenes[cmd.scene]) {
             currentScene = scenes[cmd.scene]
             state = 'EXPERIMENT_INITIALIZED'
             step = 0
             running = false
+            schemaSent = false
+            stepsSinceKeyframe = 0
+            prevEntities = {}
             console.log(`Switched to scene: ${cmd.scene}`)
           }
           break
@@ -104,10 +197,14 @@ wss.on('connection', (ws) => {
     } catch { /* ignore */ }
   })
 
-  ws.on('close', () => console.log(`Client disconnected (${wss.clients.size} total)`))
+  ws.on('close', () => {
+    clientNeedsSchema.delete(ws)
+    console.log(`Client disconnected (${wss.clients.size} total)`)
+  })
 })
 
 console.log(`Mock ARGoS WebSocket server on ws://localhost:${PORT}`)
 console.log(`Scene: ${sceneName} — ${currentScene.description}`)
+console.log(`Mode: ${deltaFlag ? 'delta (keyframe every ' + KEYFRAME_INTERVAL + ' steps)' : 'full broadcast'}`)
 console.log(`Arena: ${currentScene.arena.size.x}×${currentScene.arena.size.y}`)
 console.log(`Entities: ${currentScene.generate(0).length}`)

--- a/client-next/tests/unit/deltaProtocol.test.ts
+++ b/client-next/tests/unit/deltaProtocol.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect, beforeEach } from 'vitest'
+import { useExperimentStore } from '@/stores/experimentStore'
+import { makeEntity, makeBroadcast, makeSchema, makeDelta } from '../helpers'
+
+beforeEach(() => {
+  useExperimentStore.setState(useExperimentStore.getInitialState())
+})
+
+describe('delta protocol flow', () => {
+  test('schema → delta → delta preserves full state', () => {
+    // Schema: full initial state
+    useExperimentStore.getState().applySchema(makeSchema([
+      makeEntity('r0', 0, 0, ['0xff0000']),
+      makeEntity('r1', 1, 1, ['0x00ff00']),
+    ]))
+    expect(useExperimentStore.getState().entities.size).toBe(2)
+
+    // Delta: only r0 moved
+    useExperimentStore.getState().applyDelta(makeDelta({
+      r0: { position: { x: 2, y: 3, z: 0 } } as any,
+    }))
+
+    // r0 position updated, LEDs preserved
+    const r0 = useExperimentStore.getState().entities.get('r0')
+    expect(r0?.position).toEqual({ x: 2, y: 3, z: 0 })
+    expect((r0 as any)?.leds).toEqual(['0xff0000'])
+
+    // r1 unchanged
+    const r1 = useExperimentStore.getState().entities.get('r1')
+    expect(r1?.position).toEqual({ x: 1, y: 1, z: 0 })
+  })
+
+  test('empty delta preserves all entities', () => {
+    useExperimentStore.getState().applySchema(makeSchema([makeEntity('r0', 5, 5)]))
+    useExperimentStore.getState().applyDelta(makeDelta({}))
+    expect(useExperimentStore.getState().entities.get('r0')?.position.x).toBe(5)
+  })
+
+  test('delta can add new entities', () => {
+    useExperimentStore.getState().applySchema(makeSchema([makeEntity('r0')]))
+    useExperimentStore.getState().applyDelta(makeDelta({
+      r_new: makeEntity('r_new', 9, 9) as any,
+    }))
+    expect(useExperimentStore.getState().entities.size).toBe(2)
+    expect(useExperimentStore.getState().entities.get('r_new')?.position.x).toBe(9)
+  })
+
+  test('keyframe (schema) replaces all entities', () => {
+    useExperimentStore.getState().applySchema(makeSchema([makeEntity('r0'), makeEntity('r1')]))
+    // Keyframe with only r2
+    useExperimentStore.getState().applySchema(makeSchema([makeEntity('r2', 3, 3)]))
+    expect(useExperimentStore.getState().entities.size).toBe(1)
+    expect(useExperimentStore.getState().entities.has('r2')).toBe(true)
+  })
+})

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -42,7 +42,7 @@ Critique phases are explicit gates — they prevent premature implementation and
 | PN | Title | Status | Effort | Requires | GitHub Issue |
 |----|-------|--------|--------|----------|-------------|
 | PN-001 | [Client-Next CMake Build & Install](PN-001-client-next-default.md) | 🔵 IMPLEMENTATION | ~2h | None | [#1](https://github.com/dcat52/argos3-webviz/issues/1) |
-| PN-002 | [Delta Encoding Protocol](PN-002-delta-protocol.md) | 📋 INVESTIGATION | ~2h | PN-006 | [#2](https://github.com/dcat52/argos3-webviz/issues/2) |
+| PN-002 | [Delta Encoding Protocol](PN-002-delta-protocol.md) | 🔵 IMPLEMENTATION | ~2h | PN-006 | [#2](https://github.com/dcat52/argos3-webviz/issues/2) |
 | PN-003 | [Seamless Record → Replay](PN-003-recorder-replay.md) | 📋 INVESTIGATION | ~4h | None | [#3](https://github.com/dcat52/argos3-webviz/issues/3) |
 | PN-004 | [Generic Data Visualization System](PN-004-viz-system.md) | 📋 INVESTIGATION | ~5.5h | None | [#4](https://github.com/dcat52/argos3-webviz/issues/4) |
 | PN-005 | [Dynamic Computed Fields & State Exposure](PN-005-computed-fields.md) | 📋 INVESTIGATION | ~9h | None | [#5](https://github.com/dcat52/argos3-webviz/issues/5) |

--- a/src/plugins/simulator/visualizations/webviz/webviz.cpp
+++ b/src/plugins/simulator/visualizations/webviz/webviz.cpp
@@ -46,6 +46,8 @@ namespace argos {
       t_tree, "ff_draw_frames_every", m_unDrawFrameEvery, UInt16(2));
     GetNodeAttributeOrDefault(
       t_tree, "delta", m_bDeltaMode, false);
+    GetNodeAttributeOrDefault(
+      t_tree, "keyframe_interval", m_unKeyframeInterval, UInt32(100));
 
     /* Get options for ssl certificate from XML */
     GetNodeAttributeOrDefault(
@@ -496,6 +498,7 @@ namespace argos {
 
     m_eExperimentState = Webviz::EExperimentState::EXPERIMENT_INITIALIZED;
     m_bSchemaSent = false;  /* Re-send schema on next broadcast */
+    m_unStepsSinceKeyframe = 0;
 
     /* Change state and emit signals */
     m_cWebServer->EmitEvent("Experiment reset", m_eExperimentState);
@@ -580,13 +583,15 @@ namespace argos {
 
     /************* Delta encoding *************/
     if (m_bDeltaMode) {
-      if (!m_bSchemaSent) {
-        /* Send full schema first */
+      if (!m_bSchemaSent || m_unStepsSinceKeyframe >= m_unKeyframeInterval) {
+        /* Send full schema: first frame or keyframe interval */
         cStateJson["type"] = "schema";
         cStateJson["entities"] = cCurrentEntities;
         m_cPrevEntities = cCurrentEntities;
         m_bSchemaSent = true;
+        m_unStepsSinceKeyframe = 0;
       } else {
+        m_unStepsSinceKeyframe++;
         /* Compute delta */
         cStateJson["type"] = "delta";
         nlohmann::json cDelta = nlohmann::json::object();

--- a/src/plugins/simulator/visualizations/webviz/webviz.h
+++ b/src/plugins/simulator/visualizations/webviz/webviz.h
@@ -173,6 +173,12 @@ namespace argos {
     /** Whether to use delta encoding for broadcasts */
     bool m_bDeltaMode = false;
 
+    /** Keyframe interval: send full schema every N steps in delta mode */
+    UInt32 m_unKeyframeInterval = 100;
+
+    /** Steps since last keyframe */
+    UInt32 m_unStepsSinceKeyframe = 0;
+
     /** Previous entities JSON for delta computation */
     nlohmann::json m_cPrevEntities;
 


### PR DESCRIPTION
## Proposal

Closes #2

## Description

Delta encoding protocol hardening: keyframe interval, late-joiner support, and mock server delta mode.

### Mock server (`--delta` flag)
- First message is `schema` (full state), subsequent are `delta` (changed fields only)
- Keyframe every 100 steps (periodic full schema)
- Late-joining clients get immediate schema
- Reset clears delta state

### C++ plugin
- `keyframe_interval="100"` XML attribute on `<webviz>`
- Periodic schema broadcast every N steps
- Keyframe counter resets on experiment reset

### Tests
- 4 new unit tests covering schema→delta flow, empty deltas, new entities via delta, keyframe replacement
- Total: 32 unit tests passing

### Not in this PR (follow-up)
- Client hello/capability negotiation (complex, low priority — backwards compat already works)
- Per-WebSocket delta state in C++ (requires webserver refactor)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Components Affected

- [x] Next client (`client-next/`)
- [x] C++ plugin (`src/`)
- [x] Protocol / message format

## Checklist

- [x] Tests pass locally
- [x] Backwards compatible (delta is opt-in via --delta flag / XML attribute)
