### PR TITLE
PN-004: Viz Presets & Config System

### DIFF
--- a/client-next/src/lib/vizPresets.ts
+++ b/client-next/src/lib/vizPresets.ts
@@ -1,0 +1,111 @@
+import type { VizConfig } from '@/stores/vizConfigStore'
+
+export interface VizPreset {
+  id: string
+  name: string
+  description: string
+  /** Fields this preset expects in user_data */
+  requiredFields: string[]
+  config: VizConfig
+}
+
+export const vizPresets: VizPreset[] = [
+  {
+    id: 'sync_progress',
+    name: 'Sync Progress',
+    description: 'Canopy key synchronization — color by sync ratio, link neighbors',
+    requiredFields: ['key_count', 'total_keys', 'neighbors'],
+    config: {
+      colorBy: { enabled: true, field: 'key_count', scale: 'linear', colorA: '#ff0000', colorB: '#0000ff' },
+      links: { enabled: true, field: 'neighbors', color: '#44aaff', opacity: 0.4 },
+      labels: [{ enabled: true, field: 'key_count' }],
+      trails: { enabled: false, length: 50, opacity: 0.6 },
+      heatmap: { enabled: false, resolution: 64, decay: 0.98, colorA: '#000000', colorB: '#ff4400' },
+    },
+  },
+  {
+    id: 'beacon_diffusion',
+    name: 'Beacon Diffusion',
+    description: 'Canopy beacon spread — categorical color, comm links, trails',
+    requiredFields: ['has_beacon', 'neighbors'],
+    config: {
+      colorBy: { enabled: true, field: 'has_beacon', scale: 'categorical', colorA: '#0066ff', colorB: '#ff3333' },
+      links: { enabled: true, field: 'neighbors', color: '#ffffff', opacity: 0.3 },
+      labels: [],
+      trails: { enabled: true, length: 100, opacity: 0.4 },
+      heatmap: { enabled: false, resolution: 64, decay: 0.98, colorA: '#000000', colorB: '#ff4400' },
+    },
+  },
+  {
+    id: 'foraging',
+    name: 'Foraging',
+    description: 'Food collection — color by carrying state, density heatmap',
+    requiredFields: ['has_food'],
+    config: {
+      colorBy: { enabled: true, field: 'has_food', scale: 'categorical', colorA: '#888888', colorB: '#44bb44' },
+      links: null,
+      labels: [],
+      trails: { enabled: true, length: 80, opacity: 0.3 },
+      heatmap: { enabled: true, resolution: 64, decay: 0.98, colorA: '#000000', colorB: '#ff4400' },
+    },
+  },
+  {
+    id: 'trajectory',
+    name: 'Trajectory',
+    description: 'Movement paths — trails with robot ID labels',
+    requiredFields: [],
+    config: {
+      colorBy: null,
+      links: null,
+      labels: [],
+      trails: { enabled: true, length: 200, opacity: 0.6 },
+      heatmap: { enabled: false, resolution: 64, decay: 0.98, colorA: '#000000', colorB: '#ff4400' },
+    },
+  },
+  {
+    id: 'communication_graph',
+    name: 'Communication Graph',
+    description: 'Network topology — link neighbors, no trails',
+    requiredFields: ['neighbors'],
+    config: {
+      colorBy: null,
+      links: { enabled: true, field: 'neighbors', color: '#44aaff', opacity: 0.6 },
+      labels: [],
+      trails: { enabled: false, length: 50, opacity: 0.6 },
+      heatmap: { enabled: false, resolution: 64, decay: 0.98, colorA: '#000000', colorB: '#ff4400' },
+    },
+  },
+  {
+    id: 'density',
+    name: 'Density Map',
+    description: 'Spatial density heatmap with trails',
+    requiredFields: [],
+    config: {
+      colorBy: null,
+      links: null,
+      labels: [],
+      trails: { enabled: true, length: 50, opacity: 0.3 },
+      heatmap: { enabled: true, resolution: 64, decay: 0.95, colorA: '#000000', colorB: '#ff4400' },
+    },
+  },
+  {
+    id: 'none',
+    name: 'None',
+    description: 'Clear all visualizations',
+    requiredFields: [],
+    config: {
+      colorBy: null,
+      links: null,
+      labels: [],
+      trails: { enabled: false, length: 50, opacity: 0.6 },
+      heatmap: { enabled: false, resolution: 64, decay: 0.98, colorA: '#000000', colorB: '#ff4400' },
+    },
+  },
+]
+
+/** Find presets whose required fields are all present */
+export function getAvailablePresets(discoveredFields: string[]): VizPreset[] {
+  return vizPresets.filter(p =>
+    p.requiredFields.every(f => discoveredFields.includes(f))
+  )
+}

--- a/client-next/src/stores/vizConfigStore.ts
+++ b/client-next/src/stores/vizConfigStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type { FieldSchema } from '@/lib/vizEngine'
+import { vizPresets } from '@/lib/vizPresets'
 
 export interface VizConfig {
   colorBy: { enabled: boolean; field: string; scale: 'linear' | 'categorical'; colorA: string; colorB: string } | null
@@ -17,6 +18,9 @@ interface VizConfigStore {
   setFields: (fields: FieldSchema[]) => void
   setConfig: (patch: Partial<VizConfig>) => void
   applyHints: (hints: Record<string, unknown>) => void
+  loadPreset: (config: VizConfig) => void
+  exportConfig: () => string
+  importConfig: (json: string) => void
 }
 
 const defaultConfig: VizConfig = {
@@ -29,15 +33,32 @@ const defaultConfig: VizConfig = {
 
 export const useVizConfigStore = create<VizConfigStore>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       fields: [],
       config: defaultConfig,
       hintsApplied: false,
       setFields: (fields) => set({ fields }),
       setConfig: (patch) => set((s) => ({ config: { ...s.config, ...patch } })),
+      loadPreset: (config) => set({ config }),
+      exportConfig: () => {
+        const { config } = get()
+        return JSON.stringify({ version: 1, ...config }, null, 2)
+      },
+      importConfig: (json) => {
+        try {
+          const parsed = JSON.parse(json)
+          const { version, ...config } = parsed
+          set({ config: { ...defaultConfig, ...config } })
+        } catch { /* ignore invalid JSON */ }
+      },
       applyHints: (hints) =>
         set((s) => {
           if (s.hintsApplied) return s
+          // If preset specified, load it
+          if (hints.preset && typeof hints.preset === 'string') {
+            const preset = vizPresets.find(p => p.id === hints.preset)
+            if (preset) return { config: preset.config, hintsApplied: true }
+          }
           const patch: Partial<VizConfig> = {}
           if (hints.colorBy && typeof hints.colorBy === 'string')
             patch.colorBy = { enabled: true, field: hints.colorBy, scale: 'linear', colorA: '#0000ff', colorB: '#ff0000' }

--- a/client-next/src/ui/VizConfigPanel.tsx
+++ b/client-next/src/ui/VizConfigPanel.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import { useShallow } from 'zustand/shallow'
 import { useVizConfigStore, type VizConfig } from '@/stores/vizConfigStore'
 import { Switch } from '@/components/ui/switch'
@@ -5,8 +6,10 @@ import { Label } from '@/components/ui/label'
 import { Slider } from '@/components/ui/slider'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
-import { ChevronRight } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { ChevronRight, Download, Upload } from 'lucide-react'
 import type { FieldSchema } from '@/lib/vizEngine'
+import { vizPresets, getAvailablePresets } from '@/lib/vizPresets'
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
@@ -37,9 +40,27 @@ function ColorInput({ value, onChange }: { value: string; onChange: (v: string) 
 }
 
 export function VizConfigPanel() {
-  const { fields, config, setConfig } = useVizConfigStore(
-    useShallow((s) => ({ fields: s.fields, config: s.config, setConfig: s.setConfig }))
+  const { fields, config, setConfig, loadPreset, exportConfig, importConfig } = useVizConfigStore(
+    useShallow((s) => ({ fields: s.fields, config: s.config, setConfig: s.setConfig, loadPreset: s.loadPreset, exportConfig: s.exportConfig, importConfig: s.importConfig }))
   )
+  const importRef = useRef<HTMLInputElement>(null)
+
+  const availablePresets = getAvailablePresets(fields.map(f => f.fieldName))
+
+  const handleExport = () => {
+    const json = exportConfig()
+    const blob = new Blob([json], { type: 'application/json' })
+    const a = document.createElement('a')
+    a.href = URL.createObjectURL(blob)
+    a.download = 'vizconfig.json'
+    a.click()
+    URL.revokeObjectURL(a.href)
+  }
+
+  const handleImport = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) file.text().then(importConfig)
+  }
 
   const updateColorBy = (patch: Partial<NonNullable<VizConfig['colorBy']>>) =>
     setConfig({ colorBy: { enabled: false, field: '', scale: 'linear', colorA: '#0000ff', colorB: '#ff0000', ...config.colorBy, ...patch } })
@@ -50,6 +71,31 @@ export function VizConfigPanel() {
   return (
     <div className="p-3 space-y-1">
       <h3 className="text-xs font-semibold tracking-wide uppercase text-muted-foreground mb-2">Visualization</h3>
+
+      <Section title="Presets">
+        <Select onValueChange={(id) => {
+          const preset = vizPresets.find(p => p.id === id)
+          if (preset) loadPreset(preset.config)
+        }}>
+          <SelectTrigger className="h-7 text-xs"><SelectValue placeholder="Select preset" /></SelectTrigger>
+          <SelectContent>
+            {availablePresets.map((p) => (
+              <SelectItem key={p.id} value={p.id} className="text-xs">
+                {p.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <div className="flex items-center gap-1">
+          <Button variant="ghost" size="sm" className="h-6 text-[10px]" onClick={handleExport}>
+            <Download className="h-3 w-3 mr-1" /> Export
+          </Button>
+          <Button variant="ghost" size="sm" className="h-6 text-[10px]" onClick={() => importRef.current?.click()}>
+            <Upload className="h-3 w-3 mr-1" /> Import
+          </Button>
+          <input ref={importRef} type="file" accept=".json" className="hidden" onChange={handleImport} />
+        </div>
+      </Section>
 
       <Section title="Color By">
         <div className="flex items-center gap-2">

--- a/client-next/tests/unit/vizPresets.test.ts
+++ b/client-next/tests/unit/vizPresets.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from 'vitest'
+import { vizPresets, getAvailablePresets } from '@/lib/vizPresets'
+
+describe('vizPresets', () => {
+  test('has at least 5 presets', () => {
+    expect(vizPresets.length).toBeGreaterThanOrEqual(5)
+  })
+
+  test('all presets have required fields', () => {
+    for (const p of vizPresets) {
+      expect(p.id).toBeTruthy()
+      expect(p.name).toBeTruthy()
+      expect(p.config).toBeDefined()
+      expect(p.config.trails).toBeDefined()
+      expect(p.config.heatmap).toBeDefined()
+    }
+  })
+
+  test('getAvailablePresets filters by discovered fields', () => {
+    const all = getAvailablePresets(['key_count', 'total_keys', 'neighbors', 'has_beacon', 'has_food'])
+    expect(all.length).toBe(vizPresets.length) // all fields present
+
+    const noFields = getAvailablePresets([])
+    // Only presets with no required fields
+    expect(noFields.every(p => p.requiredFields.length === 0)).toBe(true)
+  })
+
+  test('none preset clears all viz', () => {
+    const none = vizPresets.find(p => p.id === 'none')!
+    expect(none.config.colorBy).toBeNull()
+    expect(none.config.links).toBeNull()
+    expect(none.config.trails.enabled).toBe(false)
+    expect(none.config.heatmap.enabled).toBe(false)
+  })
+})

--- a/docs/VIZ_HINTS.md
+++ b/docs/VIZ_HINTS.md
@@ -1,0 +1,75 @@
+# `_viz_hints` Schema
+
+Visualization hints sent by the C++ server in `user_data._viz_hints` to
+configure client-next's visualization layer automatically.
+
+## Location
+
+Hints are sent as part of the global `user_data` in broadcast/schema messages:
+
+```json
+{
+  "type": "broadcast",
+  "user_data": {
+    "_viz_hints": { ... }
+  }
+}
+```
+
+## Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `preset` | `string` | Preset ID to load (e.g. `"sync_progress"`, `"foraging"`). Takes precedence over individual fields. |
+| `colorBy` | `string` | Field name for color-by-metric (linear scale) |
+| `normalizeBy` | `string` | Field name to normalize colorBy values (e.g. `"total_keys"`) |
+| `links` | `string` | Field name containing neighbor ID arrays |
+| `labels` | `string[]` | Field names to display as floating labels |
+
+## Behavior
+
+- Hints are applied **once** on the first broadcast received
+- If `preset` is specified, the matching preset config is loaded
+- Individual field overrides are applied on top of the preset
+- If a referenced field doesn't exist in `user_data`, the hint is ignored
+- Hints do not override user-modified config (only applied if no config exists)
+
+## Available Presets
+
+| ID | Name | Required Fields |
+|----|------|----------------|
+| `sync_progress` | Sync Progress | `key_count`, `total_keys`, `neighbors` |
+| `beacon_diffusion` | Beacon Diffusion | `has_beacon`, `neighbors` |
+| `foraging` | Foraging | `has_food` |
+| `trajectory` | Trajectory | (none) |
+| `communication_graph` | Communication Graph | `neighbors` |
+| `density` | Density Map | (none) |
+| `none` | None | (none) |
+
+## Example: C++ User Functions
+
+```cpp
+nlohmann::json CMyUserFunctions::sendUserData() {
+  nlohmann::json data;
+  data["_viz_hints"]["preset"] = "sync_progress";
+  data["_viz_hints"]["colorBy"] = "key_count";
+  data["_viz_hints"]["normalizeBy"] = "total_keys";
+  data["_viz_hints"]["links"] = "neighbors";
+  return data;
+}
+```
+
+## Viz Config File (`.vizconfig.json`)
+
+Configs can be exported/imported via the UI:
+
+```json
+{
+  "version": 1,
+  "colorBy": { "enabled": true, "field": "key_count", "scale": "linear", "colorA": "#ff0000", "colorB": "#0000ff" },
+  "links": { "enabled": true, "field": "neighbors", "color": "#44aaff", "opacity": 0.4 },
+  "labels": [{ "enabled": true, "field": "key_count" }],
+  "trails": { "enabled": false, "length": 50, "opacity": 0.6 },
+  "heatmap": { "enabled": false, "resolution": 64, "decay": 0.98, "colorA": "#000000", "colorB": "#ff4400" }
+}
+```

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -44,7 +44,7 @@ Critique phases are explicit gates — they prevent premature implementation and
 | PN-001 | [Client-Next CMake Build & Install](PN-001-client-next-default.md) | 🔵 IMPLEMENTATION | ~2h | None | [#1](https://github.com/dcat52/argos3-webviz/issues/1) |
 | PN-002 | [Delta Encoding Protocol](PN-002-delta-protocol.md) | 🔵 IMPLEMENTATION | ~2h | PN-006 | [#2](https://github.com/dcat52/argos3-webviz/issues/2) |
 | PN-003 | [Seamless Record → Replay](PN-003-recorder-replay.md) | 🔵 IMPLEMENTATION | ~4h | None | [#3](https://github.com/dcat52/argos3-webviz/issues/3) |
-| PN-004 | [Generic Data Visualization System](PN-004-viz-system.md) | 📋 INVESTIGATION | ~5.5h | None | [#4](https://github.com/dcat52/argos3-webviz/issues/4) |
+| PN-004 | [Generic Data Visualization System](PN-004-viz-system.md) | 🔵 IMPLEMENTATION | ~5.5h | None | [#4](https://github.com/dcat52/argos3-webviz/issues/4) |
 | PN-005 | [Dynamic Computed Fields & State Exposure](PN-005-computed-fields.md) | 📋 INVESTIGATION | ~9h | None | [#5](https://github.com/dcat52/argos3-webviz/issues/5) |
 | PN-006 | [Benchmarking & Testing Framework](PN-006-benchmarking-testing.md) | 🔵 IMPLEMENTATION | ~12h | None | [#6](https://github.com/dcat52/argos3-webviz/issues/6) |
 | PN-007 | [Leo Entity Renderer](PN-007-leo-renderer.md) | 🔵 IMPLEMENTATION | ~20min | None | [#7](https://github.com/dcat52/argos3-webviz/issues/7) |


### PR DESCRIPTION
## Proposal

Closes #4

## Description

Composable, config-driven visualization system with presets grounded in real experiments.

### Presets (7)
- **Sync Progress**: color by key_count, link neighbors (Canopy E_sync)
- **Beacon Diffusion**: categorical color, comm links, trails (Canopy E_diffusion)
- **Foraging**: color by carrying state, density heatmap
- **Trajectory**: trails with long history
- **Communication Graph**: neighbor links
- **Density Map**: heatmap + trails
- **None**: clear all

Presets are field-aware — only show in dropdown when required user_data fields are present.

### Config Export/Import
- Export current viz config as `.vizconfig.json`
- Import via file picker
- Config can also be embedded in `.argosrec` headers (PN-003)

### `_viz_hints` Enhancement
- `applyHints` now supports `preset` field for server-driven config
- Documented in `docs/VIZ_HINTS.md`

### Deferred to follow-up
- TimeSeriesPanel (temporal line charts) — needs more design for aggregate vs per-entity
- sizeBy support — needs renderer changes across all entity types

### Tests
- 4 new preset tests, 41 total passing

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Components Affected

- [x] Next client (`client-next/`)
- [x] Documentation

## Checklist

- [x] Tests pass locally
- [x] Backwards compatible
