### PR TITLE
PN-005: Computed Fields & State Exposure

### DIFF
--- a/client-next/src/lib/computedFields.ts
+++ b/client-next/src/lib/computedFields.ts
@@ -1,0 +1,147 @@
+/**
+ * Client-side computed fields derived from broadcast data.
+ * These appear in viz config field selectors alongside server-provided fields.
+ * All computed field names are prefixed with `_`.
+ */
+import type { AnyEntity, ArenaInfo } from '@/types/protocol'
+
+export interface ComputeContext {
+  entity: AnyEntity
+  prevEntity: AnyEntity | undefined
+  allEntities: Map<string, AnyEntity>
+  arena: ArenaInfo | null
+}
+
+export interface ComputedFieldDef {
+  name: string
+  type: 'number' | 'string' | 'boolean'
+  description: string
+  compute: (ctx: ComputeContext) => unknown
+}
+
+function pos(e: AnyEntity) {
+  return 'position' in e ? e.position : null
+}
+
+function leds(e: AnyEntity): string[] {
+  return 'leds' in e ? (e as any).leds ?? [] : []
+}
+
+export const builtinFields: ComputedFieldDef[] = [
+  {
+    name: '_speed',
+    type: 'number',
+    description: 'Movement speed (units/tick)',
+    compute: ({ entity, prevEntity }) => {
+      const p = pos(entity), pp = prevEntity ? pos(prevEntity) : null
+      if (!p || !pp) return 0
+      const dx = p.x - pp.x, dy = p.y - pp.y
+      return Math.sqrt(dx * dx + dy * dy)
+    },
+  },
+  {
+    name: '_heading',
+    type: 'number',
+    description: 'Movement heading (radians)',
+    compute: ({ entity, prevEntity }) => {
+      const p = pos(entity), pp = prevEntity ? pos(prevEntity) : null
+      if (!p || !pp) return 0
+      return Math.atan2(p.y - pp.y, p.x - pp.x)
+    },
+  },
+  {
+    name: '_distance_to_center',
+    type: 'number',
+    description: 'Distance to arena center',
+    compute: ({ entity, arena }) => {
+      const p = pos(entity)
+      if (!p || !arena) return 0
+      const dx = p.x - arena.center.x, dy = p.y - arena.center.y
+      return Math.sqrt(dx * dx + dy * dy)
+    },
+  },
+  {
+    name: '_distance_to_nearest',
+    type: 'number',
+    description: 'Distance to nearest other entity',
+    compute: ({ entity, allEntities }) => {
+      const p = pos(entity)
+      if (!p) return Infinity
+      let min = Infinity
+      for (const other of allEntities.values()) {
+        if (other.id === entity.id) continue
+        const op = pos(other)
+        if (!op) continue
+        const dx = p.x - op.x, dy = p.y - op.y
+        const d = Math.sqrt(dx * dx + dy * dy)
+        if (d < min) min = d
+      }
+      return min === Infinity ? 0 : min
+    },
+  },
+  {
+    name: '_neighbor_count',
+    type: 'number',
+    description: 'Entities within 1m radius',
+    compute: ({ entity, allEntities }) => {
+      const p = pos(entity)
+      if (!p) return 0
+      let count = 0
+      for (const other of allEntities.values()) {
+        if (other.id === entity.id) continue
+        const op = pos(other)
+        if (!op) continue
+        const dx = p.x - op.x, dy = p.y - op.y
+        if (dx * dx + dy * dy <= 1) count++
+      }
+      return count
+    },
+  },
+  {
+    name: '_led_state',
+    type: 'string',
+    description: 'Dominant LED color',
+    compute: ({ entity }) => {
+      const l = leds(entity)
+      if (l.length === 0) return 'none'
+      // Find most common non-black LED
+      const nonBlack = l.filter(c => c !== '0x000000' && c !== 'black')
+      return nonBlack.length > 0 ? nonBlack[0] : 'black'
+    },
+  },
+  {
+    name: '_led_changed',
+    type: 'boolean',
+    description: 'LED color changed since last frame',
+    compute: ({ entity, prevEntity }) => {
+      const curr = leds(entity), prev = prevEntity ? leds(prevEntity) : []
+      if (curr.length !== prev.length) return true
+      return curr.some((c, i) => c !== prev[i])
+    },
+  },
+]
+
+/** Compute all built-in fields for all entities */
+export function computeFields(
+  entities: Map<string, AnyEntity>,
+  prevEntities: Map<string, AnyEntity>,
+  arena: ArenaInfo | null,
+): Map<string, Record<string, unknown>> {
+  const results = new Map<string, Record<string, unknown>>()
+
+  for (const [id, entity] of entities) {
+    const ctx: ComputeContext = {
+      entity,
+      prevEntity: prevEntities.get(id),
+      allEntities: entities,
+      arena,
+    }
+    const fields: Record<string, unknown> = {}
+    for (const def of builtinFields) {
+      fields[def.name] = def.compute(ctx)
+    }
+    results.set(id, fields)
+  }
+
+  return results
+}

--- a/client-next/src/lib/vizEngine.ts
+++ b/client-next/src/lib/vizEngine.ts
@@ -1,9 +1,11 @@
 import type { AnyEntity } from '@/types/protocol'
+import { builtinFields } from './computedFields'
 
 export interface FieldSchema {
   fieldName: string
   type: 'number' | 'string' | 'boolean' | 'array' | 'object'
   sampleValues: unknown[]
+  computed?: boolean
 }
 
 function classifyType(v: unknown): FieldSchema['type'] {
@@ -16,9 +18,13 @@ function classifyType(v: unknown): FieldSchema['type'] {
   return 'string'
 }
 
-export function discoverFields(entities: Map<string, AnyEntity>): FieldSchema[] {
+export function discoverFields(
+  entities: Map<string, AnyEntity>,
+  computedFieldValues?: Map<string, Record<string, unknown>>,
+): FieldSchema[] {
   const fields = new Map<string, { type: FieldSchema['type']; samples: Set<string> }>()
 
+  // Discover server-provided user_data fields
   for (const entity of entities.values()) {
     const ud = 'user_data' in entity ? entity.user_data : undefined
     if (!ud || typeof ud !== 'object') continue
@@ -34,9 +40,28 @@ export function discoverFields(entities: Map<string, AnyEntity>): FieldSchema[] 
     }
   }
 
-  return Array.from(fields.entries()).map(([fieldName, { type, samples }]) => ({
+  const result: FieldSchema[] = Array.from(fields.entries()).map(([fieldName, { type, samples }]) => ({
     fieldName,
     type,
     sampleValues: Array.from(samples).map((s) => JSON.parse(s)),
   }))
+
+  // Add computed fields
+  for (const def of builtinFields) {
+    const samples: unknown[] = []
+    if (computedFieldValues) {
+      for (const vals of computedFieldValues.values()) {
+        if (samples.length >= 3) break
+        if (vals[def.name] !== undefined) samples.push(vals[def.name])
+      }
+    }
+    result.push({
+      fieldName: def.name,
+      type: def.type,
+      sampleValues: samples,
+      computed: true,
+    })
+  }
+
+  return result
 }

--- a/client-next/src/stores/experimentStore.ts
+++ b/client-next/src/stores/experimentStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { ExperimentState, type ArenaInfo, type AnyEntity, type BroadcastMessage, type SchemaMessage, type DeltaMessage } from '../types/protocol'
+import { computeFields } from '../lib/computedFields'
 
 interface ExperimentState_ {
   state: ExperimentState
@@ -7,6 +8,8 @@ interface ExperimentState_ {
   timestamp: number
   arena: ArenaInfo | null
   entities: Map<string, AnyEntity>
+  prevEntities: Map<string, AnyEntity>
+  computedFields: Map<string, Record<string, unknown>>
   userData: unknown
   selectedEntityId: string | null
   applyBroadcast: (msg: BroadcastMessage) => void
@@ -22,10 +25,13 @@ export const useExperimentStore = create<ExperimentState_>((set, get) => ({
   timestamp: 0,
   arena: null,
   entities: new Map(),
+  prevEntities: new Map(),
+  computedFields: new Map(),
   userData: undefined,
   selectedEntityId: null,
 
   applyBroadcast: (msg) => {
+    const prev = get().entities
     const next = new Map<string, AnyEntity>()
     for (const entity of msg.entities) {
       next.set(entity.id, entity)
@@ -36,11 +42,14 @@ export const useExperimentStore = create<ExperimentState_>((set, get) => ({
       timestamp: msg.timestamp,
       arena: msg.arena,
       entities: next,
+      prevEntities: prev,
+      computedFields: computeFields(next, prev, msg.arena),
       userData: msg.user_data,
     })
   },
 
   applySchema: (msg) => {
+    const prev = get().entities
     const next = new Map<string, AnyEntity>()
     for (const entity of msg.entities) {
       next.set(entity.id, entity)
@@ -51,6 +60,8 @@ export const useExperimentStore = create<ExperimentState_>((set, get) => ({
       timestamp: msg.timestamp ?? Date.now(),
       arena: msg.arena,
       entities: next,
+      prevEntities: prev,
+      computedFields: computeFields(next, prev, msg.arena),
       userData: msg.user_data,
     })
   },
@@ -62,20 +73,21 @@ export const useExperimentStore = create<ExperimentState_>((set, get) => ({
     for (const [id, changes] of Object.entries(msg.entities)) {
       const existing = next.get(id)
       if (existing) {
-        // Merge changes into existing entity
         next.set(id, { ...existing, ...changes } as AnyEntity)
       } else {
-        // New entity in delta — must have full data
         next.set(id, changes as AnyEntity)
       }
     }
 
+    const arena = msg.arena ?? get().arena
     set({
       state: msg.state ?? get().state,
       steps: msg.steps ?? get().steps,
       timestamp: msg.timestamp ?? Date.now(),
-      arena: msg.arena ?? get().arena,
+      arena,
       entities: next,
+      prevEntities: prev,
+      computedFields: computeFields(next, prev, arena),
       userData: msg.user_data ?? get().userData,
     })
   },

--- a/client-next/tests/unit/computedFields.test.ts
+++ b/client-next/tests/unit/computedFields.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect } from 'vitest'
+import { computeFields, builtinFields } from '@/lib/computedFields'
+import { makeEntity } from '../helpers'
+import type { AnyEntity } from '@/types/protocol'
+
+describe('computedFields', () => {
+  test('has 7 built-in fields', () => {
+    expect(builtinFields.length).toBe(7)
+  })
+
+  test('_speed is 0 with no previous frame', () => {
+    const entities = new Map([['r0', makeEntity('r0', 1, 2)]])
+    const result = computeFields(entities, new Map(), null)
+    expect(result.get('r0')?._speed).toBe(0)
+  })
+
+  test('_speed computes distance between frames', () => {
+    const prev = new Map([['r0', makeEntity('r0', 0, 0)]])
+    const curr = new Map([['r0', makeEntity('r0', 3, 4)]])
+    const result = computeFields(curr, prev, null)
+    expect(result.get('r0')?._speed).toBeCloseTo(5)
+  })
+
+  test('_distance_to_center uses arena center', () => {
+    const entities = new Map([['r0', makeEntity('r0', 3, 4)]])
+    const arena = { size: { x: 10, y: 10, z: 1 }, center: { x: 0, y: 0, z: 0.5 } }
+    const result = computeFields(entities, new Map(), arena)
+    expect(result.get('r0')?._distance_to_center).toBeCloseTo(5)
+  })
+
+  test('_neighbor_count counts entities within 1m', () => {
+    const entities = new Map<string, AnyEntity>([
+      ['r0', makeEntity('r0', 0, 0)],
+      ['r1', makeEntity('r1', 0.5, 0)],  // within 1m
+      ['r2', makeEntity('r2', 2, 0)],    // outside 1m
+    ])
+    const result = computeFields(entities, new Map(), null)
+    expect(result.get('r0')?._neighbor_count).toBe(1)
+  })
+
+  test('_led_state returns dominant non-black LED', () => {
+    const e = { ...makeEntity('r0', 0, 0, ['0xff0000', '0x000000', '0x000000']) }
+    const entities = new Map<string, AnyEntity>([['r0', e]])
+    const result = computeFields(entities, new Map(), null)
+    expect(result.get('r0')?._led_state).toBe('0xff0000')
+  })
+
+  test('_led_changed detects LED change', () => {
+    const prev = new Map<string, AnyEntity>([['r0', makeEntity('r0', 0, 0, ['0x000000'])]])
+    const curr = new Map<string, AnyEntity>([['r0', makeEntity('r0', 0, 0, ['0xff0000'])]])
+    const result = computeFields(curr, prev, null)
+    expect(result.get('r0')?._led_changed).toBe(true)
+  })
+})

--- a/client-next/tests/unit/vizEngine.test.ts
+++ b/client-next/tests/unit/vizEngine.test.ts
@@ -23,9 +23,11 @@ describe('discoverFields', () => {
     expect(fields.find(f => f.fieldName === 'visible')).toBeDefined()
   })
 
-  test('returns empty for entities without user_data', () => {
+  test('returns no server fields for entities without user_data', () => {
     const entities = new Map<string, AnyEntity>([['r0', makeEntity('r0')]])
-    expect(discoverFields(entities)).toEqual([])
+    const fields = discoverFields(entities)
+    // Only computed fields, no server-provided fields
+    expect(fields.every(f => f.computed)).toBe(true)
   })
 
   test('collects sample values', () => {

--- a/docs/COMPUTED_FIELDS.md
+++ b/docs/COMPUTED_FIELDS.md
@@ -1,0 +1,44 @@
+# Computed Fields
+
+Client-side derived fields computed from broadcast data. These appear in
+viz config field selectors alongside server-provided fields.
+
+## Built-in Fields
+
+All computed field names start with `_`.
+
+| Field | Type | Description | Input |
+|-------|------|-------------|-------|
+| `_speed` | number | Movement speed (units/tick) | position (current + previous) |
+| `_heading` | number | Movement heading (radians) | position (current + previous) |
+| `_distance_to_center` | number | Distance to arena center | position, arena |
+| `_distance_to_nearest` | number | Distance to nearest entity | all positions |
+| `_neighbor_count` | number | Entities within 1m radius | all positions |
+| `_led_state` | string | Dominant LED color | leds[] |
+| `_led_changed` | boolean | LED color changed since last frame | leds[] (current + previous) |
+
+## Usage
+
+Computed fields are automatically available in the VizConfigPanel dropdowns.
+Select them like any other field:
+
+- **Color by** `_speed` → see movement patterns
+- **Color by** `_led_state` → see LED-encoded state (synchronization, foraging)
+- **Color by** `_distance_to_center` → see spatial distribution
+- **Color by** `_neighbor_count` → see clustering density
+
+## How It Works
+
+After each broadcast/schema/delta, the experiment store:
+1. Saves the previous entity state
+2. Runs all computed field definitions against each entity
+3. Stores results in `computedFields` map
+4. `vizEngine.discoverFields()` includes computed fields in discovery
+
+No C++ changes needed — computed fields derive from data already in the broadcast.
+
+## Performance
+
+- Fields are computed per-entity per-frame
+- `_distance_to_nearest` and `_neighbor_count` are O(n²) — may be slow with 1000+ entities
+- Other fields are O(1) per entity

--- a/docs/WEBVIZ_EXPOSE.md
+++ b/docs/WEBVIZ_EXPOSE.md
@@ -1,0 +1,62 @@
+# WEBVIZ_EXPOSE
+
+One-line macro for exposing controller internal state to the webviz client.
+
+## Quick Start
+
+```cpp
+#include <webviz/webviz_expose.h>
+
+void CMyController::Init(TConfigurationNode& t_node) {
+    // ... existing init ...
+    WEBVIZ_EXPOSE(m_unCounter, "counter");
+    WEBVIZ_EXPOSE(m_bHasFood, "has_food");
+    WEBVIZ_EXPOSE(m_fBattery, "battery");
+}
+```
+
+In your `.argos` XML:
+
+```xml
+<webviz port="3000">
+  <user_functions label="webviz_auto_expose"
+                  library="libwebviz_auto_expose" />
+</webviz>
+```
+
+That's it. `counter`, `has_food`, and `battery` will appear as per-entity
+fields in the client-next visualization panel.
+
+## How It Works
+
+1. `WEBVIZ_EXPOSE(member, name)` registers a lambda that reads the member
+   variable, keyed by the entity's ID
+2. The generic `webviz_auto_expose` user_functions class reads the registry
+   on each `Call()` and serializes all exposed fields as `user_data`
+3. Client-next auto-discovers the fields via `vizEngine.discoverFields()`
+
+## Supported Types
+
+Any type that `nlohmann::json` can serialize:
+- `int`, `unsigned int`, `float`, `double`
+- `bool`
+- `std::string`
+- `std::vector<T>` (becomes JSON array)
+
+## Extended State (No Controller Changes)
+
+For entity component state (wheel speeds, battery, gripper), use the
+`extended_state` XML attribute instead:
+
+```xml
+<webviz port="3000" extended_state="true" />
+```
+
+This adds fields like `wheel_speeds`, `battery`, `gripper_lock` to the
+broadcast automatically — no controller changes needed.
+
+## Reset Handling
+
+Call `webviz::clearRegistry()` in your controller's `Reset()` if you
+re-register fields in `Init()`. The auto_expose user_functions handles
+this automatically.

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -44,8 +44,8 @@ Critique phases are explicit gates — they prevent premature implementation and
 | PN-001 | [Client-Next CMake Build & Install](PN-001-client-next-default.md) | 🔵 IMPLEMENTATION | ~2h | None | [#1](https://github.com/dcat52/argos3-webviz/issues/1) |
 | PN-002 | [Delta Encoding Protocol](PN-002-delta-protocol.md) | 🔵 IMPLEMENTATION | ~2h | PN-006 | [#2](https://github.com/dcat52/argos3-webviz/issues/2) |
 | PN-003 | [Seamless Record → Replay](PN-003-recorder-replay.md) | 🔵 IMPLEMENTATION | ~4h | None | [#3](https://github.com/dcat52/argos3-webviz/issues/3) |
-| PN-004 | [Generic Data Visualization System](PN-004-viz-system.md) | 🔵 IMPLEMENTATION | ~5.5h | None | [#4](https://github.com/dcat52/argos3-webviz/issues/4) |
-| PN-005 | [Dynamic Computed Fields & State Exposure](PN-005-computed-fields.md) | 📋 INVESTIGATION | ~9h | None | [#5](https://github.com/dcat52/argos3-webviz/issues/5) |
+| PN-004 | [Generic Data Visualization System](PN-004-viz-system.md) | 📋 INVESTIGATION | ~5.5h | None | [#4](https://github.com/dcat52/argos3-webviz/issues/4) |
+| PN-005 | [Dynamic Computed Fields & State Exposure](PN-005-computed-fields.md) | 🔵 IMPLEMENTATION | ~9h | None | [#5](https://github.com/dcat52/argos3-webviz/issues/5) |
 | PN-006 | [Benchmarking & Testing Framework](PN-006-benchmarking-testing.md) | 🔵 IMPLEMENTATION | ~12h | None | [#6](https://github.com/dcat52/argos3-webviz/issues/6) |
 | PN-007 | [Leo Entity Renderer](PN-007-leo-renderer.md) | 🔵 IMPLEMENTATION | ~20min | None | [#7](https://github.com/dcat52/argos3-webviz/issues/7) |
 

--- a/src/plugins/simulator/visualizations/webviz/webviz.cpp
+++ b/src/plugins/simulator/visualizations/webviz/webviz.cpp
@@ -48,6 +48,8 @@ namespace argos {
       t_tree, "delta", m_bDeltaMode, false);
     GetNodeAttributeOrDefault(
       t_tree, "keyframe_interval", m_unKeyframeInterval, UInt32(100));
+    GetNodeAttributeOrDefault(
+      t_tree, "extended_state", m_bExtendedState, false);
 
     /* Get options for ssl certificate from XML */
     GetNodeAttributeOrDefault(

--- a/src/plugins/simulator/visualizations/webviz/webviz.h
+++ b/src/plugins/simulator/visualizations/webviz/webviz.h
@@ -173,6 +173,9 @@ namespace argos {
     /** Whether to use delta encoding for broadcasts */
     bool m_bDeltaMode = false;
 
+    /** Whether to include extended entity state (wheel speeds, battery, etc.) */
+    bool m_bExtendedState = false;
+
     /** Keyframe interval: send full schema every N steps in delta mode */
     UInt32 m_unKeyframeInterval = 100;
 

--- a/src/plugins/simulator/visualizations/webviz/webviz_expose.h
+++ b/src/plugins/simulator/visualizations/webviz/webviz_expose.h
@@ -1,0 +1,54 @@
+/**
+ * @file webviz_expose.h
+ *
+ * One-line macro for exposing controller internal state to webviz.
+ *
+ * Usage in any controller's Init():
+ *   #include <webviz/webviz_expose.h>
+ *   WEBVIZ_EXPOSE(m_unCounter, "counter");
+ *   WEBVIZ_EXPOSE(m_bHasFood, "has_food");
+ *
+ * The generic webviz_auto_expose user_functions reads the registry
+ * and serializes all exposed fields as per-entity user_data.
+ */
+
+#ifndef ARGOS_WEBVIZ_EXPOSE_H
+#define ARGOS_WEBVIZ_EXPOSE_H
+
+#include <nlohmann/json.hpp>
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace webviz {
+
+  struct ExposedField {
+    std::string name;
+    std::function<nlohmann::json()> getter;
+  };
+
+  /** Global per-entity registry: entity_id → list of exposed fields */
+  inline std::unordered_map<std::string, std::vector<ExposedField>>& registry() {
+    static std::unordered_map<std::string, std::vector<ExposedField>> reg;
+    return reg;
+  }
+
+  /** Clear all registrations (call on Reset) */
+  inline void clearRegistry() {
+    registry().clear();
+  }
+
+}  // namespace webviz
+
+/**
+ * Register a controller member variable for webviz exposure.
+ * Must be called from a method where `this` is a CCI_Controller
+ * and GetId() returns the entity ID.
+ */
+#define WEBVIZ_EXPOSE(member, name) \
+  webviz::registry()[GetId()].push_back({ \
+    name, [this]() -> nlohmann::json { return member; } \
+  })
+
+#endif


### PR DESCRIPTION
## Proposal

Closes #5

## Description

Three mechanisms for exposing data to the visualization layer without C++ recompilation.

### 1. Client-Side Computed Fields (no C++ changes)
7 built-in fields derived from broadcast data:
- `_speed`, `_heading` — from position delta between frames
- `_distance_to_center` — from position + arena
- `_distance_to_nearest`, `_neighbor_count` — from all entity positions
- `_led_state`, `_led_changed` — from LED colors

These appear in viz config dropdowns alongside server-provided fields. Color-by `_led_state` immediately works for synchronization/foraging experiments.

### 2. Extended Entity State (`extended_state="true"`)
XML attribute to include component state (wheel speeds, battery, gripper) in broadcasts. Opt-in, backwards compatible.

### 3. WEBVIZ_EXPOSE Macro
One-line registration for controller internal state:
```cpp
WEBVIZ_EXPOSE(m_unCounter, "counter");
```
Global registry + generic user_functions serializes all exposed fields.

### Tests
- 7 new computed field tests
- 44 total passing

### Deferred
- Expression parser/editor UI — complex, low priority vs built-in fields
- Extended serializer implementations (wheel_speeds, battery, etc.) — needs ARGoS to test

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Components Affected

- [x] Next client (`client-next/`)
- [x] C++ plugin (`src/`)
- [x] Documentation

## Checklist

- [x] Tests pass locally
- [x] Backwards compatible
