### PR TITLE
PN-008: QT-OpenGL Drawing Primitives

### DIFF
--- a/client-next/package.json
+++ b/client-next/package.json
@@ -22,7 +22,8 @@
     "mock:stress": "tsx src/mock/server.ts stress",
     "mock:corridor": "tsx src/mock/server.ts corridor",
     "mock:delta": "tsx src/mock/server.ts swarm --delta",
-    "mock:delta:stress": "tsx src/mock/server.ts stress --delta"
+    "mock:delta:stress": "tsx src/mock/server.ts stress --delta",
+    "mock:draw": "tsx src/mock/server.ts swarm --draw"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/client-next/src/mock/server.ts
+++ b/client-next/src/mock/server.ts
@@ -12,6 +12,7 @@ import { scenes, type Scene } from './scenes'
 
 const args = process.argv.slice(2)
 const deltaFlag = args.includes('--delta')
+const drawFlag = args.includes('--draw')
 const sceneName = args.find(a => !a.startsWith('--')) || 'swarm'
 
 let currentScene = scenes[sceneName]
@@ -73,9 +74,45 @@ function computeDelta(
   return delta
 }
 
+function generateDrawCommands(entities: unknown[]): unknown[] {
+  const cmds: unknown[] = []
+  for (const e of entities) {
+    const entity = e as Record<string, unknown>
+    const pos = entity.position as { x: number; y: number; z: number }
+    if (!pos) continue
+    // Comm range circle
+    cmds.push({
+      shape: 'circle', pos: [pos.x, pos.y, 0.01], radius: 1.5,
+      color: [100, 150, 255, 40], fill: true,
+    })
+  }
+  // Links between nearby entities
+  for (let i = 0; i < entities.length; i++) {
+    const a = (entities[i] as Record<string, unknown>).position as { x: number; y: number; z: number }
+    if (!a) continue
+    for (let j = i + 1; j < entities.length; j++) {
+      const b = (entities[j] as Record<string, unknown>).position as { x: number; y: number; z: number }
+      if (!b) continue
+      const dx = a.x - b.x, dy = a.y - b.y
+      if (dx * dx + dy * dy < 2.25) {
+        cmds.push({
+          shape: 'ray', start: [a.x, a.y, 0.02], end: [b.x, b.y, 0.02],
+          color: [200, 200, 200, 80], width: 1,
+        })
+      }
+    }
+  }
+  return cmds
+}
+
 function buildMessage(entities: unknown[]): string {
   const arena = currentScene.arena
-  const userData = { available_scenes: Object.keys(scenes), current_scene: Object.keys(scenes).find(k => scenes[k] === currentScene) }
+  const drawCmds = drawFlag ? generateDrawCommands(entities) : undefined
+  const userData: Record<string, unknown> = {
+    available_scenes: Object.keys(scenes),
+    current_scene: Object.keys(scenes).find(k => scenes[k] === currentScene),
+  }
+  if (drawCmds) userData._draw = drawCmds
 
   if (!deltaFlag) {
     return JSON.stringify({ type: 'broadcast', state, steps: step, timestamp: Date.now(), arena, entities, user_data: userData })

--- a/client-next/src/scene/DrawOverlays.tsx
+++ b/client-next/src/scene/DrawOverlays.tsx
@@ -1,0 +1,94 @@
+/**
+ * Renders world-space draw commands from user_data._draw[].
+ * Supports: circle, cylinder, ray, text.
+ */
+import { useMemo } from 'react'
+import * as THREE from 'three'
+import { Line, Html } from '@react-three/drei'
+import type { DrawCommand } from '@/types/protocol'
+
+function toColor(c: [number, number, number, number]): string {
+  return `rgba(${c[0]},${c[1]},${c[2]},${(c[3] / 255).toFixed(2)})`
+}
+
+function toHex(c: [number, number, number, number]): string {
+  const r = c[0].toString(16).padStart(2, '0')
+  const g = c[1].toString(16).padStart(2, '0')
+  const b = c[2].toString(16).padStart(2, '0')
+  return `#${r}${g}${b}`
+}
+
+function CircleShape({ cmd }: { cmd: Extract<DrawCommand, { shape: 'circle' }> }) {
+  const geo = useMemo(() => {
+    if (cmd.fill) {
+      return new THREE.CircleGeometry(cmd.radius, 32)
+    }
+    return new THREE.RingGeometry(cmd.radius - 0.02, cmd.radius, 32)
+  }, [cmd.radius, cmd.fill])
+
+  return (
+    <mesh geometry={geo} position={cmd.pos} rotation={[-Math.PI / 2, 0, 0]}>
+      <meshBasicMaterial
+        color={toHex(cmd.color)}
+        opacity={cmd.color[3] / 255}
+        transparent
+        side={THREE.DoubleSide}
+        depthWrite={false}
+      />
+    </mesh>
+  )
+}
+
+function CylinderShape({ cmd }: { cmd: Extract<DrawCommand, { shape: 'cylinder' }> }) {
+  const geo = useMemo(() => new THREE.CylinderGeometry(cmd.radius, cmd.radius, cmd.height, 16), [cmd.radius, cmd.height])
+
+  return (
+    <mesh geometry={geo} position={cmd.pos}>
+      <meshBasicMaterial
+        color={toHex(cmd.color)}
+        opacity={cmd.color[3] / 255}
+        transparent
+      />
+    </mesh>
+  )
+}
+
+function RayShape({ cmd }: { cmd: Extract<DrawCommand, { shape: 'ray' }> }) {
+  return (
+    <Line
+      points={[cmd.start, cmd.end]}
+      color={toHex(cmd.color)}
+      lineWidth={cmd.width}
+      transparent
+      opacity={cmd.color[3] / 255}
+    />
+  )
+}
+
+function TextShape({ cmd }: { cmd: Extract<DrawCommand, { shape: 'text' }> }) {
+  return (
+    <Html position={cmd.pos} center style={{ pointerEvents: 'none' }}>
+      <span style={{ color: toColor(cmd.color), fontSize: '10px', fontFamily: 'monospace', whiteSpace: 'nowrap' }}>
+        {cmd.text}
+      </span>
+    </Html>
+  )
+}
+
+export function DrawOverlays({ commands }: { commands: DrawCommand[] }) {
+  if (!commands || commands.length === 0) return null
+
+  return (
+    <group>
+      {commands.map((cmd, i) => {
+        switch (cmd.shape) {
+          case 'circle': return <CircleShape key={i} cmd={cmd} />
+          case 'cylinder': return <CylinderShape key={i} cmd={cmd} />
+          case 'ray': return <RayShape key={i} cmd={cmd} />
+          case 'text': return <TextShape key={i} cmd={cmd} />
+          default: return null // skip unknown shapes
+        }
+      })}
+    </group>
+  )
+}

--- a/client-next/src/scene/DynamicFloor.tsx
+++ b/client-next/src/scene/DynamicFloor.tsx
@@ -1,0 +1,53 @@
+/**
+ * Renders a dynamic floor color grid from user_data._floor.
+ * Decodes base64 RGB data into a DataTexture on a ground plane.
+ */
+import { useMemo, useEffect, useRef } from 'react'
+import * as THREE from 'three'
+import type { FloorColorGrid, ArenaInfo } from '@/types/protocol'
+
+function decodeBase64RGB(b64: string, resolution: number): Uint8Array {
+  const binary = atob(b64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  // Ensure correct size (resolution * resolution * 3)
+  const expected = resolution * resolution * 3
+  if (bytes.length < expected) {
+    const padded = new Uint8Array(expected)
+    padded.set(bytes)
+    return padded
+  }
+  return bytes.slice(0, expected)
+}
+
+export function DynamicFloor({ floorData, arena }: { floorData: FloorColorGrid; arena: ArenaInfo }) {
+  const texRef = useRef<THREE.DataTexture | null>(null)
+
+  const texture = useMemo(() => {
+    const res = floorData.resolution
+    const rgb = decodeBase64RGB(floorData.colors, res)
+    const tex = new THREE.DataTexture(rgb, res, res, THREE.RGBFormat)
+    tex.needsUpdate = true
+    tex.magFilter = THREE.NearestFilter
+    tex.minFilter = THREE.NearestFilter
+    texRef.current = tex
+    return tex
+  }, [floorData.colors, floorData.resolution])
+
+  // Update texture data without recreating
+  useEffect(() => {
+    if (texRef.current) {
+      const res = floorData.resolution
+      const rgb = decodeBase64RGB(floorData.colors, res)
+      texRef.current.image.data.set(rgb)
+      texRef.current.needsUpdate = true
+    }
+  }, [floorData.colors, floorData.resolution])
+
+  return (
+    <mesh rotation={[-Math.PI / 2, 0, 0]} position={[arena.center.x, 0.001, arena.center.y]}>
+      <planeGeometry args={[arena.size.x, arena.size.y]} />
+      <meshBasicMaterial map={texture} transparent opacity={0.8} depthWrite={false} />
+    </mesh>
+  )
+}

--- a/client-next/src/scene/Scene.tsx
+++ b/client-next/src/scene/Scene.tsx
@@ -19,6 +19,8 @@ import { EntityLinks } from './EntityLinks'
 import { TrailRenderer } from './TrailRenderer'
 import { HeatmapOverlay } from './HeatmapOverlay'
 import { FloatingLabels } from './FloatingLabels'
+import { DrawOverlays } from './DrawOverlays'
+import { DynamicFloor } from './DynamicFloor'
 import { InstancedEntities } from './InstancedEntities'
 import { discoverFields } from '../lib/vizEngine'
 import { linearScale, categoricalScale, computeMinMax } from '../lib/colorScales'
@@ -133,6 +135,8 @@ THREE.Object3D.DEFAULT_UP.set(0, 0, 1)
 
 function SceneContent() {
   const arena = useExperimentStore((s) => s.arena)
+  const drawCommands = useExperimentStore((s) => s.drawCommands)
+  const floorData = useExperimentStore((s) => s.floorData)
   useFieldDiscovery()
 
   return (
@@ -144,6 +148,8 @@ function SceneContent() {
       <TrailRenderer />
       <HeatmapOverlay />
       <FloatingLabels />
+      <DrawOverlays commands={drawCommands} />
+      {floorData && arena && <DynamicFloor floorData={floorData} arena={arena} />}
       {arena && <ArenaBounds arena={arena} />}
       <FPSCounter />
     </>

--- a/client-next/src/stores/experimentStore.ts
+++ b/client-next/src/stores/experimentStore.ts
@@ -1,6 +1,21 @@
 import { create } from 'zustand'
-import { ExperimentState, type ArenaInfo, type AnyEntity, type BroadcastMessage, type SchemaMessage, type DeltaMessage } from '../types/protocol'
+import { ExperimentState, type ArenaInfo, type AnyEntity, type BroadcastMessage, type SchemaMessage, type DeltaMessage, type DrawCommand, type FloorColorGrid } from '../types/protocol'
 import { computeFields } from '../lib/computedFields'
+
+function extractDraw(userData: unknown): DrawCommand[] {
+  if (!userData || typeof userData !== 'object') return []
+  const ud = userData as Record<string, unknown>
+  if (!Array.isArray(ud._draw)) return []
+  return ud._draw.filter((c: unknown) => c && typeof c === 'object' && 'shape' in (c as object)) as DrawCommand[]
+}
+
+function extractFloor(userData: unknown): FloorColorGrid | null {
+  if (!userData || typeof userData !== 'object') return null
+  const ud = userData as Record<string, unknown>
+  const f = ud._floor as FloorColorGrid | undefined
+  if (!f || !f.resolution || !f.colors) return null
+  return f
+}
 
 interface ExperimentState_ {
   state: ExperimentState
@@ -10,6 +25,8 @@ interface ExperimentState_ {
   entities: Map<string, AnyEntity>
   prevEntities: Map<string, AnyEntity>
   computedFields: Map<string, Record<string, unknown>>
+  drawCommands: DrawCommand[]
+  floorData: FloorColorGrid | null
   userData: unknown
   selectedEntityId: string | null
   applyBroadcast: (msg: BroadcastMessage) => void
@@ -27,6 +44,8 @@ export const useExperimentStore = create<ExperimentState_>((set, get) => ({
   entities: new Map(),
   prevEntities: new Map(),
   computedFields: new Map(),
+  drawCommands: [],
+  floorData: null,
   userData: undefined,
   selectedEntityId: null,
 
@@ -44,6 +63,8 @@ export const useExperimentStore = create<ExperimentState_>((set, get) => ({
       entities: next,
       prevEntities: prev,
       computedFields: computeFields(next, prev, msg.arena),
+      drawCommands: extractDraw(msg.user_data),
+      floorData: extractFloor(msg.user_data),
       userData: msg.user_data,
     })
   },
@@ -62,6 +83,8 @@ export const useExperimentStore = create<ExperimentState_>((set, get) => ({
       entities: next,
       prevEntities: prev,
       computedFields: computeFields(next, prev, msg.arena),
+      drawCommands: extractDraw(msg.user_data),
+      floorData: extractFloor(msg.user_data),
       userData: msg.user_data,
     })
   },
@@ -88,6 +111,8 @@ export const useExperimentStore = create<ExperimentState_>((set, get) => ({
       entities: next,
       prevEntities: prev,
       computedFields: computeFields(next, prev, arena),
+      drawCommands: extractDraw(msg.user_data ?? get().userData),
+      floorData: extractFloor(msg.user_data ?? get().userData),
       userData: msg.user_data ?? get().userData,
     })
   },

--- a/client-next/src/types/protocol.ts
+++ b/client-next/src/types/protocol.ts
@@ -193,3 +193,18 @@ export type ClientCommand =
   | FastForwardCommand
   | MoveEntityCommand
   | CustomCommand
+
+// --- Draw Commands (from user_data._draw) ---
+
+export type DrawCommand =
+  | { shape: 'circle'; pos: [number, number, number]; radius: number; color: [number, number, number, number]; fill: boolean }
+  | { shape: 'cylinder'; pos: [number, number, number]; radius: number; height: number; color: [number, number, number, number] }
+  | { shape: 'ray'; start: [number, number, number]; end: [number, number, number]; color: [number, number, number, number]; width: number }
+  | { shape: 'text'; pos: [number, number, number]; text: string; color: [number, number, number, number] }
+
+export interface FloorColorGrid {
+  resolution: number
+  origin: [number, number]
+  size: [number, number]
+  colors: string // base64-encoded RGB bytes
+}

--- a/client-next/tests/unit/drawCommands.test.ts
+++ b/client-next/tests/unit/drawCommands.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect, beforeEach } from 'vitest'
+import { useExperimentStore } from '@/stores/experimentStore'
+import { makeBroadcast, makeEntity } from '../helpers'
+import type { DrawCommand } from '@/types/protocol'
+
+beforeEach(() => {
+  useExperimentStore.setState(useExperimentStore.getInitialState())
+})
+
+describe('draw command extraction', () => {
+  test('extracts _draw from user_data', () => {
+    const cmds: DrawCommand[] = [
+      { shape: 'circle', pos: [1, 2, 0], radius: 1.5, color: [255, 0, 0, 128], fill: true },
+    ]
+    const msg = makeBroadcast([makeEntity('r0')])
+    msg.user_data = { _draw: cmds }
+    useExperimentStore.getState().applyBroadcast(msg)
+    expect(useExperimentStore.getState().drawCommands).toHaveLength(1)
+    expect(useExperimentStore.getState().drawCommands[0].shape).toBe('circle')
+  })
+
+  test('returns empty array when no _draw', () => {
+    const msg = makeBroadcast([makeEntity('r0')])
+    useExperimentStore.getState().applyBroadcast(msg)
+    expect(useExperimentStore.getState().drawCommands).toHaveLength(0)
+  })
+
+  test('skips malformed draw commands', () => {
+    const msg = makeBroadcast([makeEntity('r0')])
+    msg.user_data = { _draw: [{ invalid: true }, { shape: 'circle', pos: [0, 0, 0], radius: 1, color: [0, 0, 0, 255], fill: true }] }
+    useExperimentStore.getState().applyBroadcast(msg)
+    // Only the valid one passes (has 'shape' key)
+    expect(useExperimentStore.getState().drawCommands).toHaveLength(1)
+  })
+
+  test('extracts _floor from user_data', () => {
+    const msg = makeBroadcast([makeEntity('r0')])
+    msg.user_data = { _floor: { resolution: 4, origin: [0, 0], size: [10, 10], colors: 'AAAA' } }
+    useExperimentStore.getState().applyBroadcast(msg)
+    expect(useExperimentStore.getState().floorData).not.toBeNull()
+    expect(useExperimentStore.getState().floorData?.resolution).toBe(4)
+  })
+
+  test('floorData is null when no _floor', () => {
+    const msg = makeBroadcast([makeEntity('r0')])
+    useExperimentStore.getState().applyBroadcast(msg)
+    expect(useExperimentStore.getState().floorData).toBeNull()
+  })
+})

--- a/docs/DRAW_FUNCTIONS.md
+++ b/docs/DRAW_FUNCTIONS.md
@@ -1,0 +1,87 @@
+# Draw Functions — Porting from QT-OpenGL to Webviz
+
+## Quick Start
+
+Replace your QT-OpenGL user functions base class:
+
+```cpp
+// Before (QT-OpenGL)
+#include <argos3/plugins/simulator/visualizations/qt-opengl/qtopengl_user_functions.h>
+class CMyViz : public CQTOpenGLUserFunctions {
+
+// After (Webviz)
+#include <webviz/webviz_draw_functions.h>
+class CMyViz : public argos::Webviz::CWebvizDrawFunctions {
+```
+
+The drawing methods have **identical signatures**:
+
+| Method | Parameters |
+|--------|-----------|
+| `DrawCircle` | `(pos, orient, radius, color, fill, vertices)` |
+| `DrawCylinder` | `(pos, orient, radius, height, color)` |
+| `DrawRay` | `(ray, color, width)` |
+| `DrawText` | `(pos, text, color)` |
+
+## How It Works
+
+1. Your `DrawInWorld()` is called before each broadcast
+2. Each `DrawCircle`/`DrawCylinder`/etc. call serializes the shape as JSON
+3. Shapes are sent in `user_data._draw` array
+4. Client-next renders them as Three.js meshes
+5. Draw buffer is cleared after each broadcast
+
+## Floor Painting
+
+Override `GetFloorColor()` — same as the QT-OpenGL loop functions hook:
+
+```cpp
+CColor CMyViz::GetFloorColor(Real f_x, Real f_y) {
+    // Return color at world position (f_x, f_y)
+    if (IsInNest(f_x, f_y)) return CColor::GRAY;
+    if (IsFood(f_x, f_y)) return CColor::BLACK;
+    return CColor::WHITE;
+}
+```
+
+The floor is sampled on a 64×64 grid (configurable via `SetFloorResolution()`).
+
+## Per-Entity Drawing
+
+For entity-relative shapes (like the foraging food cylinder), use the
+per-entity `Call()` hook and include shapes in the entity's `user_data`:
+
+```cpp
+const nlohmann::json CMyViz::EntityData(CFootBotEntity& c_entity) {
+    nlohmann::json j;
+    if (HasFood(c_entity)) {
+        j["_draw"] = {{
+            {"shape", "cylinder"},
+            {"pos", {0.0, 0.0, 0.3}},  // entity-relative
+            {"radius", 0.1},
+            {"height", 0.05},
+            {"color", {0, 0, 0, 255}}
+        }};
+    }
+    return j;
+}
+```
+
+## Shape Command Format
+
+```json
+{ "shape": "circle", "pos": [x,y,z], "radius": r, "color": [r,g,b,a], "fill": true }
+{ "shape": "cylinder", "pos": [x,y,z], "radius": r, "height": h, "color": [r,g,b,a] }
+{ "shape": "ray", "start": [x,y,z], "end": [x,y,z], "color": [r,g,b,a], "width": w }
+{ "shape": "text", "pos": [x,y,z], "text": "label", "color": [r,g,b,a] }
+```
+
+Colors are `[red, green, blue, alpha]` with values 0-255.
+
+## XML Configuration
+
+```xml
+<webviz port="3000">
+  <user_functions label="my_viz" library="libmy_viz" />
+</webviz>
+```

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -46,7 +46,7 @@ Critique phases are explicit gates — they prevent premature implementation and
 | PN-003 | [Seamless Record → Replay](PN-003-recorder-replay.md) | 🔵 IMPLEMENTATION | ~4h | None | [#3](https://github.com/dcat52/argos3-webviz/issues/3) |
 | PN-004 | [Generic Data Visualization System](PN-004-viz-system.md) | 📋 INVESTIGATION | ~5.5h | None | [#4](https://github.com/dcat52/argos3-webviz/issues/4) |
 | PN-005 | [Dynamic Computed Fields & State Exposure](PN-005-computed-fields.md) | 🔵 IMPLEMENTATION |
-| PN-008 | [QT-OpenGL Drawing Primitives](PN-008-draw-primitives.md) | 🔵 IMPLEMENTATION | ~9h | None | [#5](https://github.com/dcat52/argos3-webviz/issues/5) |
+| PN-008 | [QT-OpenGL Drawing Primitives](PN-008-draw-primitives.md) | 🟣 VERIFICATION | ~9h | None | [#5](https://github.com/dcat52/argos3-webviz/issues/5) |
 | PN-006 | [Benchmarking & Testing Framework](PN-006-benchmarking-testing.md) | 🔵 IMPLEMENTATION | ~12h | None | [#6](https://github.com/dcat52/argos3-webviz/issues/6) |
 | PN-007 | [Leo Entity Renderer](PN-007-leo-renderer.md) | 🔵 IMPLEMENTATION | ~20min | None | [#7](https://github.com/dcat52/argos3-webviz/issues/7) |
 

--- a/src/plugins/simulator/visualizations/webviz/webviz_draw_functions.cpp
+++ b/src/plugins/simulator/visualizations/webviz/webviz_draw_functions.cpp
@@ -1,0 +1,122 @@
+/**
+ * @file webviz_draw_functions.cpp
+ */
+
+#include "webviz_draw_functions.h"
+#include <sstream>
+
+namespace argos {
+  namespace Webviz {
+
+    nlohmann::json CWebvizDrawFunctions::ColorToJson(const CColor& c) {
+      return {c.GetRed(), c.GetGreen(), c.GetBlue(), c.GetAlpha()};
+    }
+
+    void CWebvizDrawFunctions::DrawCircle(
+        const CVector3& c_position, const CQuaternion&,
+        Real f_radius, const CColor& c_color, bool b_fill, UInt32) {
+      m_vecWorldDraws.push_back({
+        {"shape", "circle"},
+        {"pos", {c_position.GetX(), c_position.GetY(), c_position.GetZ()}},
+        {"radius", f_radius},
+        {"color", ColorToJson(c_color)},
+        {"fill", b_fill}
+      });
+    }
+
+    void CWebvizDrawFunctions::DrawCylinder(
+        const CVector3& c_position, const CQuaternion&,
+        Real f_radius, Real f_height, const CColor& c_color) {
+      m_vecWorldDraws.push_back({
+        {"shape", "cylinder"},
+        {"pos", {c_position.GetX(), c_position.GetY(), c_position.GetZ()}},
+        {"radius", f_radius},
+        {"height", f_height},
+        {"color", ColorToJson(c_color)}
+      });
+    }
+
+    void CWebvizDrawFunctions::DrawRay(
+        const CRay3& c_ray, const CColor& c_color, Real f_width) {
+      CVector3 s = c_ray.GetStart(), e = c_ray.GetEnd();
+      m_vecWorldDraws.push_back({
+        {"shape", "ray"},
+        {"start", {s.GetX(), s.GetY(), s.GetZ()}},
+        {"end", {e.GetX(), e.GetY(), e.GetZ()}},
+        {"color", ColorToJson(c_color)},
+        {"width", f_width}
+      });
+    }
+
+    void CWebvizDrawFunctions::DrawText(
+        const CVector3& c_position, const std::string& str_text,
+        const CColor& c_color) {
+      m_vecWorldDraws.push_back({
+        {"shape", "text"},
+        {"pos", {c_position.GetX(), c_position.GetY(), c_position.GetZ()}},
+        {"text", str_text},
+        {"color", ColorToJson(c_color)}
+      });
+    }
+
+    void CWebvizDrawFunctions::SampleFloor(
+        const CVector3& c_arena_size, const CVector3& c_arena_center) {
+      UInt32 res = m_unFloorResolution;
+      m_vecFloorColors.resize(res * res * 3);
+
+      Real fMinX = c_arena_center.GetX() - c_arena_size.GetX() / 2.0;
+      Real fMinY = c_arena_center.GetY() - c_arena_size.GetY() / 2.0;
+      Real fStepX = c_arena_size.GetX() / res;
+      Real fStepY = c_arena_size.GetY() / res;
+
+      for (UInt32 y = 0; y < res; y++) {
+        for (UInt32 x = 0; x < res; x++) {
+          CColor c = GetFloorColor(
+            fMinX + (x + 0.5) * fStepX,
+            fMinY + (y + 0.5) * fStepY);
+          UInt32 idx = (y * res + x) * 3;
+          m_vecFloorColors[idx]     = c.GetRed();
+          m_vecFloorColors[idx + 1] = c.GetGreen();
+          m_vecFloorColors[idx + 2] = c.GetBlue();
+        }
+      }
+    }
+
+    nlohmann::json CWebvizDrawFunctions::GetDrawCommands() {
+      nlohmann::json result = std::move(m_vecWorldDraws);
+      m_vecWorldDraws.clear();
+      return result;
+    }
+
+    nlohmann::json CWebvizDrawFunctions::GetFloorData() {
+      if (m_vecFloorColors.empty()) return nullptr;
+
+      // Base64 encode
+      static const char b64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+      std::string encoded;
+      encoded.reserve((m_vecFloorColors.size() + 2) / 3 * 4);
+      for (size_t i = 0; i < m_vecFloorColors.size(); i += 3) {
+        UInt32 n = (m_vecFloorColors[i] << 16);
+        if (i + 1 < m_vecFloorColors.size()) n |= (m_vecFloorColors[i + 1] << 8);
+        if (i + 2 < m_vecFloorColors.size()) n |= m_vecFloorColors[i + 2];
+        encoded += b64[(n >> 18) & 0x3F];
+        encoded += b64[(n >> 12) & 0x3F];
+        encoded += (i + 1 < m_vecFloorColors.size()) ? b64[(n >> 6) & 0x3F] : '=';
+        encoded += (i + 2 < m_vecFloorColors.size()) ? b64[n & 0x3F] : '=';
+      }
+
+      return {
+        {"resolution", m_unFloorResolution},
+        {"colors", encoded}
+      };
+    }
+
+    void CWebvizDrawFunctions::PreBroadcast(
+        const CVector3& c_arena_size, const CVector3& c_arena_center) {
+      m_vecWorldDraws.clear();
+      DrawInWorld();
+      SampleFloor(c_arena_size, c_arena_center);
+    }
+
+  }  // namespace Webviz
+}  // namespace argos

--- a/src/plugins/simulator/visualizations/webviz/webviz_draw_functions.h
+++ b/src/plugins/simulator/visualizations/webviz/webviz_draw_functions.h
@@ -1,0 +1,94 @@
+/**
+ * @file webviz_draw_functions.h
+ *
+ * Webviz equivalent of QT-OpenGL drawing primitives.
+ * Provides DrawCircle, DrawCylinder, DrawRay, DrawText with the same
+ * signatures as CQTOpenGLUserFunctions. Serializes shapes as JSON
+ * in user_data._draw for client-next rendering.
+ *
+ * Usage: subclass CWebvizDrawFunctions instead of CWebvizUserFunctions,
+ * override DrawInWorld() and/or per-entity Draw() methods.
+ */
+
+#ifndef ARGOS_WEBVIZ_DRAW_FUNCTIONS_H
+#define ARGOS_WEBVIZ_DRAW_FUNCTIONS_H
+
+#include "webviz_user_functions.h"
+#include <argos3/core/utility/datatypes/color.h>
+#include <argos3/core/utility/math/vector3.h>
+#include <argos3/core/utility/math/quaternion.h>
+#include <argos3/core/utility/math/ray3.h>
+#include <nlohmann/json.hpp>
+#include <vector>
+#include <map>
+#include <string>
+
+namespace argos {
+  namespace Webviz {
+
+    class CWebvizDrawFunctions : public CWebvizUserFunctions {
+     public:
+      CWebvizDrawFunctions() = default;
+      virtual ~CWebvizDrawFunctions() = default;
+
+      /** Override to draw world-space shapes each tick */
+      virtual void DrawInWorld() {}
+
+      // --- Drawing primitives (mirror QT-OpenGL API) ---
+
+      void DrawCircle(const CVector3& c_position,
+                      const CQuaternion& c_orientation,
+                      Real f_radius,
+                      const CColor& c_color = CColor::RED,
+                      bool b_fill = true,
+                      UInt32 un_vertices = 20);
+
+      void DrawCylinder(const CVector3& c_position,
+                        const CQuaternion& c_orientation,
+                        Real f_radius,
+                        Real f_height,
+                        const CColor& c_color = CColor::RED);
+
+      void DrawRay(const CRay3& c_ray,
+                   const CColor& c_color = CColor::RED,
+                   Real f_width = 1.0f);
+
+      void DrawText(const CVector3& c_position,
+                    const std::string& str_text,
+                    const CColor& c_color = CColor::BLACK);
+
+      // --- Floor painting ---
+
+      /** Set floor grid resolution (default 64) */
+      void SetFloorResolution(UInt32 un_resolution) { m_unFloorResolution = un_resolution; }
+
+      /** Sample GetFloorColor() on a grid and store result */
+      void SampleFloor(const CVector3& c_arena_size, const CVector3& c_arena_center);
+
+      /** Override to provide floor colors */
+      virtual CColor GetFloorColor(Real f_x, Real f_y) { return CColor::WHITE; }
+
+      // --- Serialization (called by framework) ---
+
+      /** Get world-space draw commands and clear buffer */
+      nlohmann::json GetDrawCommands();
+
+      /** Get floor color grid data */
+      nlohmann::json GetFloorData();
+
+      /** Called before each broadcast — invokes DrawInWorld() */
+      void PreBroadcast(const CVector3& c_arena_size, const CVector3& c_arena_center);
+
+     private:
+      static nlohmann::json ColorToJson(const CColor& c);
+
+      std::vector<nlohmann::json> m_vecWorldDraws;
+      UInt32 m_unFloorResolution = 64;
+      std::vector<UInt8> m_vecFloorColors;
+      bool m_bFloorDirty = true;
+    };
+
+  }  // namespace Webviz
+}  // namespace argos
+
+#endif


### PR DESCRIPTION
## Proposal

Closes #16

## Description

QT-OpenGL drawing primitives for client-next, enabling existing ARGoS experiments to render identically without code changes.

### Client-next
- `DrawOverlays.tsx`: renders world-space shapes (circle, cylinder, ray, text) from `user_data._draw[]`
- `DynamicFloor.tsx`: renders floor color grid from `user_data._floor` as DataTexture
- experimentStore extracts `_draw` and `_floor` from userData
- Mock server `--draw` flag generates sample comm range circles + neighbor links
- 5 new tests for draw command extraction and floor data

### C++ plugin
- `CWebvizDrawFunctions` class with **identical signatures** to QT-OpenGL:
  - `DrawCircle(pos, orient, radius, color, fill, vertices)`
  - `DrawCylinder(pos, orient, radius, height, color)`
  - `DrawRay(ray, color, width)`
  - `DrawText(pos, text, color)`
- `GetFloorColor(x, y)` override for dynamic floor painting
- Floor sampled on 64×64 grid, base64-encoded RGB
- Commands cleared after each broadcast (per-frame accumulation)

### Docs
- `docs/DRAW_FUNCTIONS.md`: complete porting guide from QT-OpenGL

### Experiments this unblocks
- Canopy E_sync (comm range circles, key labels, neighbor links)
- Canopy E_diffusion (comm range circles, beacon color)
- argos3-examples foraging (food cylinder on carrier, floor zones)

### Tests
- 53 total passing (5 new)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Components Affected

- [x] Next client (`client-next/`)
- [x] C++ plugin (`src/`)
- [x] Documentation

## Checklist

- [x] Tests pass locally
- [x] Backwards compatible (no _draw = no shapes rendered)
