### PR TITLE
Entity body color support

### DIFF
--- a/client-next/src/entities/renderers/BoxRenderer.tsx
+++ b/client-next/src/entities/renderers/BoxRenderer.tsx
@@ -4,6 +4,7 @@ import { BoxEntity } from '../../types/protocol'
 export function BoxRenderer({ entity, selected, onClick, onDoubleClick, overrideColor }: EntityRendererProps) {
   const e = entity as BoxEntity
   const { position: p, orientation: q, scale: s } = e
+  const color = overrideColor ?? (selected ? '#8899aa' : (e as any).color ?? (e.is_movable ? '#4488cc' : '#555566'))
   return (
     <mesh
       position={[p.x, p.y, p.z + s.z / 2]}
@@ -15,7 +16,7 @@ export function BoxRenderer({ entity, selected, onClick, onDoubleClick, override
     >
       <boxGeometry args={[s.x, s.y, s.z]} />
       <meshPhysicalMaterial
-        color={overrideColor ?? (selected ? '#8899aa' : e.is_movable ? '#4488cc' : '#555566')}
+        color={color}
         metalness={0.1}
         roughness={0.7}
       />

--- a/client-next/src/entities/renderers/CylinderRenderer.tsx
+++ b/client-next/src/entities/renderers/CylinderRenderer.tsx
@@ -4,12 +4,13 @@ import { CylinderEntity } from '../../types/protocol'
 export function CylinderRenderer({ entity, selected, onClick, onDoubleClick, overrideColor }: EntityRendererProps) {
   const e = entity as CylinderEntity
   const { position: p, orientation: q } = e
+  const color = overrideColor ?? (selected ? '#8899aa' : (e as any).color ?? (e.is_movable ? '#44aa88' : '#555566'))
   return (
     <group position={[p.x, p.y, p.z + e.height / 2]} quaternion={[q.x, q.y, q.z, q.w]} onClick={onClick} onDoubleClick={onDoubleClick}>
       <mesh rotation={[Math.PI / 2, 0, 0]} castShadow receiveShadow>
         <cylinderGeometry args={[e.radius, e.radius, e.height, 24]} />
         <meshPhysicalMaterial
-          color={overrideColor ?? (selected ? '#8899aa' : e.is_movable ? '#44aa88' : '#555566')}
+          color={color}
           metalness={0.1}
           roughness={0.6}
         />

--- a/docs/proposals/PN-011-entity-body-color.md
+++ b/docs/proposals/PN-011-entity-body-color.md
@@ -1,0 +1,86 @@
+# Proposal: Entity Body Color Support
+
+Created: 2026-04-19
+GitHub Issue: #22
+
+## Status: 🔵 IMPLEMENTATION
+
+## Goal
+
+Add configurable body color to box and cylinder entities so all
+visualizations (QT-OpenGL, webviz) render consistent, aesthetic colors
+from a single source of truth in the ARGoS data model.
+
+## Scope Boundary
+
+**In scope:**
+- Body color attribute on CBoxEntity and CCylinderEntity
+- XML `color` attribute parsing with defaults
+- QT-OpenGL renderer reads entity color instead of hardcoding
+- Webviz serializer broadcasts color field
+- Client-next renderers use broadcast color with fallbacks
+
+**Out of scope:**
+- ❌ Alpha/transparency support (future work)
+- ❌ Robot entity colors (foot-bot, khepera, etc.)
+- ❌ Color themes or palettes
+
+## Design
+
+### Approach
+
+Add `m_cBodyColor` member to box and cylinder entity classes with
+`GetBodyColor()` / `SetBodyColor()` accessors. Parse optional `color`
+XML attribute in `Init()` with aesthetic defaults based on entity type
+and movability. All renderers read from the entity instead of hardcoding.
+
+### Defaults
+
+| Entity | Movable | Non-movable |
+|--------|---------|-------------|
+| Box | `#4488cc` bright blue | `#37649b` deep blue |
+| Cylinder | `#44aa88` teal | `#377864` deep teal |
+
+Walls can be overridden to gray via XML: `color="gray60"`
+
+### XML Usage
+
+```xml
+<box id="wall" size="4,0.1,0.5" movable="false" color="gray60">
+<box id="obstacle" size="0.3,0.3,0.5" movable="true">  <!-- uses default -->
+<cylinder id="post" radius="0.1" height="0.5" movable="false" color="yellow">
+```
+
+## Key File References
+
+| File | Change |
+|------|--------|
+| `argos3: box_entity.h/.cpp` | Added m_cBodyColor, GetBodyColor(), SetBodyColor(), XML parsing |
+| `argos3: cylinder_entity.h/.cpp` | Same |
+| `argos3: qtopengl_box.cpp` | Reads GetBodyColor() instead of MOVABLE_COLOR/NONMOVABLE_COLOR |
+| `argos3: qtopengl_cylinder.cpp` | Same |
+| `webviz: webviz_box.cpp` | Serializes color as hex string |
+| `webviz: webviz_cylinder.cpp` | Same |
+| `webviz: BoxRenderer.tsx` | Uses broadcast color, fallback to defaults |
+| `webviz: CylinderRenderer.tsx` | Same |
+
+## Dependencies
+
+- **Requires**: dcat52/argos3 `feat/entity-body-color` branch
+- **Enhanced by**: None
+- **Blocks**: None
+
+## Done When
+
+- [x] Box and cylinder entities have configurable body color
+- [x] QT-OpenGL reads from entity instead of hardcoding
+- [x] Webviz broadcasts color field
+- [x] Client-next renders broadcast color
+- [x] Backward compatible — no XML change required for existing experiments
+- [ ] Merged to master
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-04-19 | Implementation complete, PR #23 open |

--- a/src/plugins/simulator/visualizations/webviz/entity/webviz_box.cpp
+++ b/src/plugins/simulator/visualizations/webviz/entity/webviz_box.cpp
@@ -34,6 +34,14 @@ namespace argos {
 
         cJson["is_movable"] = c_entity.GetEmbodiedEntity().IsMovable();
 
+        /* Get body color */
+        const CColor& cBodyColor = c_entity.GetBodyColor();
+        std::stringstream strBodyColorStream;
+        strBodyColorStream << "#" << std::setfill('0') << std::setw(6) << std::hex
+                           << (cBodyColor.GetRed() << 16 | cBodyColor.GetGreen() << 8 |
+                               cBodyColor.GetBlue());
+        cJson["color"] = strBodyColorStream.str();
+
         /* Get Scale of the box */
         const argos::CVector3& cScale = c_entity.GetSize();
         cJson["scale"]["x"] = cScale.GetX();

--- a/src/plugins/simulator/visualizations/webviz/entity/webviz_cylinder.cpp
+++ b/src/plugins/simulator/visualizations/webviz/entity/webviz_cylinder.cpp
@@ -15,6 +15,8 @@
 #include <argos3/plugins/simulator/visualizations/webviz/webviz.h>
 
 #include <iomanip>
+
+#include <iomanip>
 #include <nlohmann/json.hpp>
 
 namespace argos {
@@ -32,6 +34,14 @@ namespace argos {
         cJson["type"] = c_entity.GetTypeDescription();
         cJson["id"] = c_entity.GetId();
         cJson["is_movable"] = c_entity.GetEmbodiedEntity().IsMovable();
+
+        /* Get body color */
+        const CColor& cBodyColor = c_entity.GetBodyColor();
+        std::stringstream strBodyColorStream;
+        strBodyColorStream << "#" << std::setfill('0') << std::setw(6) << std::hex
+                           << (cBodyColor.GetRed() << 16 | cBodyColor.GetGreen() << 8 |
+                               cBodyColor.GetBlue());
+        cJson["color"] = strBodyColorStream.str();
 
         /* Get Size of the Cylinder */
         cJson["height"] = c_entity.GetHeight();


### PR DESCRIPTION
Closes #22

## Changes
- **webviz_box.cpp**: serialize `GetBodyColor()` as hex `color` field
- **webviz_cylinder.cpp**: same
- **BoxRenderer.tsx**: use `color` from broadcast, fallback red/gray
- **CylinderRenderer.tsx**: use `color` from broadcast, fallback green/gray

## Depends on
- dcat52/argos3 `feat/entity-body-color` (adds `GetBodyColor()` to box/cylinder entities)

## Backward compatible
- Without the ARGoS core change, renderers fall back to hardcoded defaults matching QT-OpenGL

## Tests
53 passing