### PR TITLE
Collapsible sidebar groups

### DIFF
--- a/client-next/src/ui/Sidebar.tsx
+++ b/client-next/src/ui/Sidebar.tsx
@@ -1,12 +1,27 @@
+import { useMemo } from 'react'
 import { useShallow } from 'zustand/shallow'
 import { useExperimentStore } from '../stores/experimentStore'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { ChevronRight } from 'lucide-react'
 import { VizConfigPanel } from './VizConfigPanel'
 import type { AnyEntity, Vec3, Quaternion } from '../types/protocol'
 
 const fv = (v: Vec3) => `${v.x.toFixed(2)}, ${v.y.toFixed(2)}, ${v.z.toFixed(2)}`
 const fq = (q: Quaternion) => `${q.x.toFixed(2)}, ${q.y.toFixed(2)}, ${q.z.toFixed(2)}, ${q.w.toFixed(2)}`
+
+function Section({ title, children, defaultOpen = true }: { title: string; children: React.ReactNode; defaultOpen?: boolean }) {
+  return (
+    <Collapsible defaultOpen={defaultOpen}>
+      <CollapsibleTrigger className="flex items-center gap-1 w-full text-xs font-semibold uppercase text-muted-foreground py-1 group">
+        <ChevronRight className="h-3 w-3 transition-transform group-data-[panel-open]:rotate-90" />
+        {title}
+      </CollapsibleTrigger>
+      <CollapsibleContent>{children}</CollapsibleContent>
+    </Collapsible>
+  )
+}
 
 function Row({ label, value }: { label: string; value: string }) {
   return (
@@ -21,20 +36,23 @@ function Inspector({ entity }: { entity: AnyEntity }) {
   if (!('position' in entity)) return null
   return (
     <div className="p-3 space-y-1">
-      <h3 className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">Inspector</h3>
-      <Row label="ID" value={entity.id} />
-      <Row label="Type" value={entity.type} />
-      <Row label="Position" value={fv(entity.position)} />
-      <Row label="Orientation" value={fq(entity.orientation)} />
-      {'leds' in entity && entity.leds && <Row label="LEDs" value={String(entity.leds.length)} />}
-      {entity.user_data !== undefined && (
-        <div className="pt-1">
-          <span className="text-xs text-muted-foreground">User Data</span>
-          <pre className="text-[10px] text-muted-foreground mt-1 bg-muted p-1.5 rounded overflow-auto max-h-24">
-            {JSON.stringify(entity.user_data, null, 2)}
-          </pre>
+      <Section title="Inspector">
+        <div className="pl-4 space-y-0.5">
+          <Row label="ID" value={entity.id} />
+          <Row label="Type" value={entity.type} />
+          <Row label="Position" value={fv(entity.position)} />
+          <Row label="Orientation" value={fq(entity.orientation)} />
+          {'leds' in entity && entity.leds && <Row label="LEDs" value={String(entity.leds.length)} />}
+          {entity.user_data !== undefined && (
+            <div className="pt-1">
+              <span className="text-xs text-muted-foreground">User Data</span>
+              <pre className="text-[10px] text-muted-foreground mt-1 bg-muted p-1.5 rounded overflow-auto max-h-24">
+                {JSON.stringify(entity.user_data, null, 2)}
+              </pre>
+            </div>
+          )}
         </div>
-      )}
+      </Section>
     </div>
   )
 }
@@ -45,6 +63,16 @@ export function Sidebar() {
   )
   const selected = selectedEntityId ? entities.get(selectedEntityId) : undefined
 
+  const grouped = useMemo(() => {
+    const groups = new Map<string, AnyEntity[]>()
+    for (const e of entities.values()) {
+      const list = groups.get(e.type) ?? []
+      list.push(e)
+      groups.set(e.type, list)
+    }
+    return groups
+  }, [entities])
+
   return (
     <div className="h-full flex flex-col bg-card">
       {selected && (
@@ -53,26 +81,31 @@ export function Sidebar() {
           <Separator />
         </>
       )}
-      <div className="px-3 pt-2 pb-1">
-        <h3 className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">
-          Entities ({entities.size})
-        </h3>
-      </div>
       <ScrollArea className="flex-1">
-        <div className="px-2 pb-2">
-          {Array.from(entities.values()).map((e) => (
-            <button
-              key={e.id}
-              onClick={() => selectEntity(e.id)}
-              className={`block w-full text-left text-xs px-2 py-1 rounded truncate transition-colors ${
-                e.id === selectedEntityId
-                  ? 'bg-primary text-primary-foreground'
-                  : 'hover:bg-accent text-foreground'
-              }`}
-            >
-              {e.id} <span className={e.id === selectedEntityId ? 'text-primary-foreground/70' : 'text-muted-foreground'}>({e.type})</span>
-            </button>
-          ))}
+        <div className="px-3 pt-2 pb-1">
+          <Section title={`Entities (${entities.size})`}>
+            {Array.from(grouped.entries()).map(([type, list]) => (
+              <div key={type} className="pl-2">
+                <Section title={`${type} (${list.length})`} defaultOpen={false}>
+                  <div className="pl-2">
+                    {list.map((e) => (
+                      <button
+                        key={e.id}
+                        onClick={() => selectEntity(e.id)}
+                        className={`block w-full text-left text-xs px-2 py-1 rounded truncate transition-colors ${
+                          e.id === selectedEntityId
+                            ? 'bg-primary text-primary-foreground'
+                            : 'hover:bg-accent text-foreground'
+                        }`}
+                      >
+                        {e.id}
+                      </button>
+                    ))}
+                  </div>
+                </Section>
+              </div>
+            ))}
+          </Section>
         </div>
         <Separator />
         <VizConfigPanel />

--- a/client-next/src/ui/VizConfigPanel.tsx
+++ b/client-next/src/ui/VizConfigPanel.tsx
@@ -15,7 +15,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
   return (
     <Collapsible>
       <CollapsibleTrigger className="flex items-center gap-1 w-full text-xs font-semibold uppercase text-muted-foreground py-1 group">
-        <ChevronRight className="h-3 w-3 transition-transform group-data-[state=open]:rotate-90" />
+        <ChevronRight className="h-3 w-3 transition-transform group-data-[panel-open]:rotate-90" />
         {title}
       </CollapsibleTrigger>
       <CollapsibleContent className="pl-4 space-y-2 pb-2">{children}</CollapsibleContent>

--- a/docs/proposals/PN-006-benchmarking-testing.md
+++ b/docs/proposals/PN-006-benchmarking-testing.md
@@ -4,7 +4,7 @@ Created: 2026-04-13
 Baseline Commit: `aa1ffd1` (`client-next`)
 GitHub Issue: #6
 
-## Status: 🔵 IMPLEMENTATION
+## Status: ✅ COMPLETE
 <!-- 📋 INVESTIGATION → 🔍 CRITIQUE → 🟡 DESIGN → 🔍 CRITIQUE → 🔵 IMPLEMENTATION → 🟣 VERIFICATION → ✅ COMPLETE / 🔴 ABANDONED -->
 
 ## Goal

--- a/docs/proposals/PN-008-draw-primitives.md
+++ b/docs/proposals/PN-008-draw-primitives.md
@@ -4,7 +4,7 @@ Created: 2026-04-15
 Baseline Commit: `b51123c` (`client-next`)
 GitHub Issue: #16
 
-## Status: 🔵 IMPLEMENTATION
+## Status: ✅ COMPLETE
 <!-- 📋 INVESTIGATION → 🔍 CRITIQUE → 🟡 DESIGN → 🔍 CRITIQUE → 🔵 IMPLEMENTATION → 🟣 VERIFICATION → ✅ COMPLETE / 🔴 ABANDONED -->
 
 ## Goal

--- a/docs/proposals/PN-009-integration-fixes.md
+++ b/docs/proposals/PN-009-integration-fixes.md
@@ -4,7 +4,7 @@ Created: 2026-04-15
 Baseline Commit: `e4a285f` (`client-next`)
 GitHub Issue: #18
 
-## Status: 🔵 IMPLEMENTATION
+## Status: ✅ COMPLETE
 <!-- 📋 INVESTIGATION → 🔍 CRITIQUE → 🟡 DESIGN → 🔍 CRITIQUE → 🔵 IMPLEMENTATION → 🟣 VERIFICATION → ✅ COMPLETE / 🔴 ABANDONED -->
 
 ## Goal

--- a/docs/proposals/PN-010-viewport-polish.md
+++ b/docs/proposals/PN-010-viewport-polish.md
@@ -4,7 +4,7 @@ Created: 2026-04-15
 Baseline Commit: `c55a30a` (`client-next`)
 GitHub Issue: N/A
 
-## Status: 🔵 IMPLEMENTATION
+## Status: ✅ COMPLETE
 
 ## Goal
 


### PR DESCRIPTION
## Changes
- Entity list grouped by type (box, cylinder, foot-bot, etc.)
- All sections collapsible: Inspector, entity groups, viz config sections
- Entity type groups collapsed by default to reduce clutter
- Fix chevron rotation: use `data-panel-open` (base-ui) instead of `data-[state=open]`

## Tests
53 passing