### PR TITLE
Post-merge cleanup: shortcuts, proposal status

### DIFF
--- a/client-next/src/hooks/useKeyboardShortcuts.ts
+++ b/client-next/src/hooks/useKeyboardShortcuts.ts
@@ -7,16 +7,16 @@ export function useKeyboardShortcuts() {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if ((e.target as HTMLElement).tagName === 'INPUT' || (e.target as HTMLElement).tagName === 'SELECT') return
-      const { play, pause, step, reset, fastForward } = useConnectionStore.getState()
+      const { pause, step, reset, playAtSpeed } = useConnectionStore.getState()
       const { state } = useExperimentStore.getState()
+      const isRunning = state === ExperimentState.EXPERIMENT_PLAYING || state === ExperimentState.EXPERIMENT_FAST_FORWARDING
       switch (e.code) {
         case 'Space':
           e.preventDefault()
-          state === ExperimentState.EXPERIMENT_PLAYING ? pause() : play()
+          isRunning ? pause() : playAtSpeed(1)
           break
         case 'ArrowRight': e.preventDefault(); step(); break
         case 'KeyR': if (!e.metaKey && !e.ctrlKey) { e.preventDefault(); reset() } break
-        case 'KeyF': if (!e.metaKey && !e.ctrlKey) { e.preventDefault(); fastForward() } break
       }
     }
     window.addEventListener('keydown', handler)

--- a/docs/proposals/PN-012-configurable-defaults.md
+++ b/docs/proposals/PN-012-configurable-defaults.md
@@ -3,7 +3,7 @@
 Created: 2026-04-19
 GitHub Issue: N/A
 
-## Status: 🟡 DESIGN
+## Status: ✅ COMPLETE
 
 ## Goal
 

--- a/docs/proposals/PN-013-floating-panels.md
+++ b/docs/proposals/PN-013-floating-panels.md
@@ -4,7 +4,7 @@ Created: 2026-04-15
 Baseline Commit: `c55a30a` (`client-next`)
 GitHub Issue: N/A
 
-## Status: 🟡 DESIGN
+## Status: ✅ COMPLETE
 
 ## Goal
 


### PR DESCRIPTION
- Fix keyboard shortcuts to use playAtSpeed (space toggles play/pause correctly during FF)
- Remove stale F key shortcut (no longer needed with speed selector)
- Mark PN-012, PN-013 as COMPLETE