### PR TITLE
Configurable speed options in settings

### DIFF
--- a/client-next/src/stores/settingsStore.ts
+++ b/client-next/src/stores/settingsStore.ts
@@ -1,11 +1,15 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import { COLORS, CAMERA, LIMITS, RECORDING, CONNECTION, LIGHTING } from '@/lib/defaults'
+import { COLORS, CAMERA, LIMITS, RECORDING, CONNECTION, LIGHTING, SPEED_OPTIONS } from '@/lib/defaults'
+
+interface SpeedOption { value: number; label: string }
 
 interface SettingsState {
   // Connection
   wsUrl: string
   reconnectIntervalMs: number
+  // Speed
+  speedOptions: SpeedOption[]
   // Rendering
   shadows: boolean
   pixelRatio: number
@@ -37,6 +41,7 @@ interface SettingsState {
 const defaults = {
   wsUrl: `ws://${typeof window !== 'undefined' ? window.location.hostname : 'localhost'}:${CONNECTION.defaultPort}`,
   reconnectIntervalMs: CONNECTION.reconnectIntervalMs,
+  speedOptions: [...SPEED_OPTIONS],
   shadows: true,
   pixelRatio: 1,
   fov: CAMERA.fov,

--- a/client-next/src/ui/SettingsPanel.tsx
+++ b/client-next/src/ui/SettingsPanel.tsx
@@ -76,6 +76,28 @@ export function SettingsPanel({ open, onOpenChange }: { open: boolean; onOpenCha
               </Row>
             </Section>
 
+            <Section title="Speed Options">
+              <div className="space-y-1">
+                {s.speedOptions.map((o, i) => (
+                  <div key={i} className="flex items-center gap-1">
+                    <Input type="number" step="any" value={o.value} onChange={(e) => {
+                      const v = Number(e.target.value)
+                      const next = [...s.speedOptions]
+                      next[i] = { value: v, label: v >= 1000 ? '∞' : v + '×' }
+                      s.set({ speedOptions: next })
+                    }} className="w-16 h-6 text-xs" />
+                    <span className="text-xs text-muted-foreground flex-1">{o.label}</span>
+                    <Button variant="ghost" size="sm" className="h-6 w-6 p-0 text-xs text-muted-foreground" onClick={() => {
+                      s.set({ speedOptions: s.speedOptions.filter((_, j) => j !== i) })
+                    }}>×</Button>
+                  </div>
+                ))}
+                <Button variant="outline" size="sm" className="h-6 text-xs w-full" onClick={() => {
+                  s.set({ speedOptions: [...s.speedOptions.slice(0, -1), { value: 20, label: '20×' }, s.speedOptions[s.speedOptions.length - 1]] })
+                }}>+ Add</Button>
+              </div>
+            </Section>
+
             <Section title="Rendering">
               <Row label="Shadows">
                 <Switch checked={s.shadows} onCheckedChange={(v) => s.set({ shadows: v })} />

--- a/client-next/src/ui/Toolbar.tsx
+++ b/client-next/src/ui/Toolbar.tsx
@@ -16,7 +16,7 @@ import { SettingsPanel } from './SettingsPanel'
 import { useCanvasRef } from '@/stores/canvasRefStore'
 import { useVideoRecordingStore } from '@/stores/videoRecordingStore'
 import { usePanelStore } from '@/stores/panelStore'
-import { SPEED_OPTIONS } from '@/lib/defaults'
+import { useSettingsStore } from '@/stores/settingsStore'
 
 const statusColors: Record<string, string> = {
   connected: 'bg-green-500',
@@ -142,7 +142,7 @@ export function Toolbar({ viewportRef }: { viewportRef?: RefObject<HTMLDivElemen
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {SPEED_OPTIONS.map((o) => (
+            {useSettingsStore.getState().speedOptions.map((o) => (
               <SelectItem key={o.value} value={String(o.value)} className="text-xs">{o.label}</SelectItem>
             ))}
           </SelectContent>


### PR DESCRIPTION
Speed options (0.5×, 1×, 2×, etc.) are now editable in the Settings panel. Add/remove speeds, persisted to localStorage.