### PR TITLE
feat: Timeline Scrubber with keyframe-cached seek (PN-018)

### DIFF
--- a/client-next/src/hooks/useKeyboardShortcuts.ts
+++ b/client-next/src/hooks/useKeyboardShortcuts.ts
@@ -1,12 +1,35 @@
 import { useEffect } from 'react'
 import { useConnectionStore } from '@/stores/connectionStore'
 import { useExperimentStore } from '@/stores/experimentStore'
+import { useRecordingStore } from '@/stores/recordingStore'
 import { ExperimentState } from '@/types/protocol'
 
 export function useKeyboardShortcuts() {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if ((e.target as HTMLElement).tagName === 'INPUT' || (e.target as HTMLElement).tagName === 'SELECT') return
+
+      const recording = useRecordingStore.getState()
+
+      // Replay-mode shortcuts
+      if (recording.state === 'replaying') {
+        switch (e.code) {
+          case 'Space':
+            e.preventDefault()
+            recording.togglePlayPause()
+            return
+          case 'ArrowLeft':
+            e.preventDefault()
+            recording.seekTo(recording.frameIndex - (e.shiftKey ? 10 : 1))
+            return
+          case 'ArrowRight':
+            e.preventDefault()
+            recording.seekTo(recording.frameIndex + (e.shiftKey ? 10 : 1))
+            return
+        }
+      }
+
+      // Live-connection shortcuts
       const { pause, step, reset, playAtSpeed } = useConnectionStore.getState()
       const { state } = useExperimentStore.getState()
       const isRunning = state === ExperimentState.EXPERIMENT_PLAYING || state === ExperimentState.EXPERIMENT_FAST_FORWARDING

--- a/client-next/src/stores/recordingStore.ts
+++ b/client-next/src/stores/recordingStore.ts
@@ -1,7 +1,8 @@
 import { create } from 'zustand'
-import type { BroadcastMessage, SchemaMessage, DeltaMessage } from '../types/protocol'
+import type { BroadcastMessage, SchemaMessage, DeltaMessage, AnyEntity, ArenaInfo } from '../types/protocol'
 import { useExperimentStore } from './experimentStore'
 import { useConnectionStore } from './connectionStore'
+import { computeFields } from '../lib/computedFields'
 import { parseArgosrec, type ArgosrecHeader, type ArgosrecFrame } from '../protocol/argosrecParser'
 
 interface RecordedFrame {
@@ -11,10 +12,16 @@ interface RecordedFrame {
 
 type RecordingState = 'idle' | 'recording' | 'replaying'
 
+export interface KeyframeSnapshot {
+  frameIndex: number
+  entities: Map<string, AnyEntity>
+  arena: ArenaInfo | null
+  userData: unknown
+}
+
 interface RecordingStore {
   state: RecordingState
   frames: RecordedFrame[]
-  /** Frames from .argosrec files (schema/delta) */
   argosrecFrames: ArgosrecFrame[]
   argosrecHeader: ArgosrecHeader | null
   argosrecWarnings: string[]
@@ -22,8 +29,9 @@ interface RecordingStore {
   totalFrames: number
   speed: number
   playing: boolean
-  /** Whether we're replaying an argosrec file (vs live recording) */
   isArgosrec: boolean
+  keyframeCache: KeyframeSnapshot[]
+  cacheInterval: number
 
   startRecording: () => void
   stopRecording: () => void
@@ -47,7 +55,7 @@ function stopLoop() {
   replayStart = null
 }
 
-/** Apply an argosrec frame to the experiment store */
+/** Apply an argosrec frame to the experiment store (used during normal playback) */
 function applyArgosrecFrame(frame: ArgosrecFrame) {
   const store = useExperimentStore.getState()
   switch (frame.type) {
@@ -63,6 +71,189 @@ function applyArgosrecFrame(frame: ArgosrecFrame) {
   }
 }
 
+/** Check if a recording needs keyframe caching (has delta frames) */
+function needsCache(frames: ArgosrecFrame[]): boolean {
+  return frames.some(f => f.type === 'delta')
+}
+
+/** Compute adaptive cache interval based on entity count */
+export function computeCacheInterval(entityCount: number): number {
+  return Math.max(200, entityCount * 2)
+}
+
+/**
+ * Build keyframe cache by replaying frames into a local Map.
+ * Does NOT touch the experiment store — pure computation.
+ */
+export function buildKeyframeCache(
+  frames: ArgosrecFrame[],
+  interval: number,
+): KeyframeSnapshot[] {
+  if (frames.length === 0) return []
+
+  const cache: KeyframeSnapshot[] = []
+  let entities = new Map<string, AnyEntity>()
+  let arena: ArenaInfo | null = null
+  let userData: unknown = undefined
+
+  for (let i = 0; i < frames.length; i++) {
+    const frame = frames[i]
+
+    switch (frame.type) {
+      case 'schema': {
+        const msg = frame.message as SchemaMessage
+        entities = new Map<string, AnyEntity>()
+        for (const e of msg.entities) entities.set(e.id, e)
+        arena = msg.arena
+        if (msg.user_data !== undefined) userData = msg.user_data
+        break
+      }
+      case 'delta': {
+        const msg = frame.message as DeltaMessage
+        for (const [id, changes] of Object.entries(msg.entities)) {
+          const existing = entities.get(id)
+          if (existing) {
+            entities.set(id, { ...existing, ...changes } as AnyEntity)
+          } else {
+            entities.set(id, changes as AnyEntity)
+          }
+        }
+        if (msg.arena) arena = msg.arena
+        if (msg.user_data !== undefined) userData = msg.user_data
+        break
+      }
+      case 'full': {
+        const msg = frame.message as BroadcastMessage
+        entities = new Map<string, AnyEntity>()
+        for (const e of msg.entities) entities.set(e.id, e)
+        arena = msg.arena
+        if (msg.user_data !== undefined) userData = msg.user_data
+        break
+      }
+    }
+
+    if (i % interval === 0) {
+      cache.push({
+        frameIndex: i,
+        entities: structuredClone(entities),
+        arena: arena ? structuredClone(arena) : null,
+        userData: userData !== undefined ? structuredClone(userData) : undefined,
+      })
+    }
+  }
+
+  return cache
+}
+
+/**
+ * Optimized seek: restore from nearest keyframe, replay forward without
+ * calling computeFields on intermediate frames. Only one setState at the end.
+ */
+function optimizedSeek(
+  frames: ArgosrecFrame[],
+  cache: KeyframeSnapshot[],
+  targetIdx: number,
+) {
+  // Find nearest cached snapshot <= targetIdx
+  let snapshot: KeyframeSnapshot | null = null
+  for (let i = cache.length - 1; i >= 0; i--) {
+    if (cache[i].frameIndex <= targetIdx) {
+      snapshot = cache[i]
+      break
+    }
+  }
+
+  let entities: Map<string, AnyEntity>
+  let arena: ArenaInfo | null
+  let userData: unknown
+  let startFrom: number
+
+  if (snapshot) {
+    entities = structuredClone(snapshot.entities)
+    arena = snapshot.arena ? structuredClone(snapshot.arena) : null
+    userData = snapshot.userData
+    startFrom = snapshot.frameIndex + 1
+  } else {
+    // No cache hit — start from frame 0
+    entities = new Map()
+    arena = null
+    userData = undefined
+    startFrom = 0
+  }
+
+  // Replay forward to target, tracking prevEntities at target-1
+  let prevEntities = new Map(entities)
+
+  for (let i = startFrom; i <= targetIdx; i++) {
+    if (i === targetIdx) {
+      prevEntities = new Map(entities)
+    }
+    const frame = frames[i]
+    switch (frame.type) {
+      case 'schema': {
+        const msg = frame.message as SchemaMessage
+        entities = new Map<string, AnyEntity>()
+        for (const e of msg.entities) entities.set(e.id, e)
+        arena = msg.arena
+        if (msg.user_data !== undefined) userData = msg.user_data
+        break
+      }
+      case 'delta': {
+        const msg = frame.message as DeltaMessage
+        for (const [id, changes] of Object.entries(msg.entities)) {
+          const existing = entities.get(id)
+          if (existing) {
+            entities.set(id, { ...existing, ...changes } as AnyEntity)
+          } else {
+            entities.set(id, changes as AnyEntity)
+          }
+        }
+        if (msg.arena) arena = msg.arena
+        if (msg.user_data !== undefined) userData = msg.user_data
+        break
+      }
+      case 'full': {
+        const msg = frame.message as BroadcastMessage
+        entities = new Map<string, AnyEntity>()
+        for (const e of msg.entities) entities.set(e.id, e)
+        arena = msg.arena
+        if (msg.user_data !== undefined) userData = msg.user_data
+        break
+      }
+    }
+  }
+
+  // Extract draw commands and floor data from userData
+  const drawCommands = extractDraw(userData)
+  const floorData = extractFloor(userData)
+
+  // Single setState with computeFields only on the final frame
+  useExperimentStore.setState({
+    entities,
+    prevEntities,
+    arena,
+    computedFields: computeFields(entities, prevEntities, arena),
+    drawCommands,
+    floorData,
+    userData,
+  })
+}
+
+function extractDraw(userData: unknown): import('../types/protocol').DrawCommand[] {
+  if (!userData || typeof userData !== 'object') return []
+  const ud = userData as Record<string, unknown>
+  if (!Array.isArray(ud._draw)) return []
+  return ud._draw.filter((c: unknown) => c && typeof c === 'object' && 'shape' in (c as object)) as import('../types/protocol').DrawCommand[]
+}
+
+function extractFloor(userData: unknown): import('../types/protocol').FloorColorGrid | null {
+  if (!userData || typeof userData !== 'object') return null
+  const ud = userData as Record<string, unknown>
+  const f = ud._floor as import('../types/protocol').FloorColorGrid | undefined
+  if (!f || !f.resolution || !f.colors) return null
+  return f
+}
+
 function playLoop() {
   stopLoop()
   const tick = (now: number) => {
@@ -72,12 +263,11 @@ function playLoop() {
     if (replayStart === null) replayStart = now
 
     if (s.isArgosrec) {
-      // Argosrec: step-based, use speed as frames-per-second multiplier
-      const elapsed = (now - replayStart) / 1000 * s.speed * 10 // 10 fps base
+      const elapsed = (now - replayStart) / 1000 * s.speed * 10
       const targetIdx = Math.min(Math.floor(elapsed), s.argosrecFrames.length - 1)
 
       if (targetIdx > s.frameIndex) {
-        // Apply all frames between current and target (for delta correctness)
+        // During playback, apply frames sequentially (they're consecutive)
         for (let i = s.frameIndex + 1; i <= targetIdx; i++) {
           applyArgosrecFrame(s.argosrecFrames[i])
         }
@@ -89,7 +279,6 @@ function playLoop() {
         return
       }
     } else {
-      // Live recording: timestamp-based
       const elapsed = (now - replayStart) * s.speed
       const baseTime = s.frames[0]?.timestamp ?? 0
 
@@ -125,8 +314,10 @@ export const useRecordingStore = create<RecordingStore>((set, get) => ({
   speed: 1,
   playing: false,
   isArgosrec: false,
+  keyframeCache: [],
+  cacheInterval: 200,
 
-  startRecording: () => set({ state: 'recording', frames: [], argosrecFrames: [], frameIndex: 0, totalFrames: 0, isArgosrec: false }),
+  startRecording: () => set({ state: 'recording', frames: [], argosrecFrames: [], frameIndex: 0, totalFrames: 0, isArgosrec: false, keyframeCache: [], cacheInterval: 200 }),
 
   stopRecording: () => {
     const { frames } = get()
@@ -153,11 +344,26 @@ export const useRecordingStore = create<RecordingStore>((set, get) => ({
 
   loadRecording: (json) => {
     const frames = JSON.parse(json) as RecordedFrame[]
-    set({ frames, totalFrames: frames.length, frameIndex: 0, state: 'idle', isArgosrec: false })
+    set({ frames, totalFrames: frames.length, frameIndex: 0, state: 'idle', isArgosrec: false, keyframeCache: [], cacheInterval: 200 })
   },
 
   loadArgosrecFile: async (file) => {
     const result = await parseArgosrec(file)
+
+    // Build keyframe cache if recording uses deltas
+    let keyframeCache: KeyframeSnapshot[] = []
+    let cacheInterval = 200
+
+    if (needsCache(result.frames) && result.frames.length > 0) {
+      // Get entity count from first schema frame
+      const schemaFrame = result.frames.find(f => f.type === 'schema')
+      const entityCount = schemaFrame
+        ? (schemaFrame.message as SchemaMessage).entities.length
+        : 0
+      cacheInterval = computeCacheInterval(entityCount)
+      keyframeCache = buildKeyframeCache(result.frames, cacheInterval)
+    }
+
     set({
       argosrecFrames: result.frames,
       argosrecHeader: result.header,
@@ -167,8 +373,9 @@ export const useRecordingStore = create<RecordingStore>((set, get) => ({
       state: 'idle',
       isArgosrec: true,
       frames: [],
+      keyframeCache,
+      cacheInterval,
     })
-    // Auto-start replay
     if (result.frames.length > 0) {
       get().startReplay()
     }
@@ -208,7 +415,6 @@ export const useRecordingStore = create<RecordingStore>((set, get) => ({
       set({ playing: false })
     } else {
       if (frameIndex >= total - 1) {
-        // Restart from beginning
         set({ frameIndex: 0, playing: true })
         if (isArgosrec) {
           applyArgosrecFrame(argosrecFrames[0])
@@ -226,20 +432,19 @@ export const useRecordingStore = create<RecordingStore>((set, get) => ({
   setSpeed: (speed) => set({ speed }),
 
   seekTo: (idx) => {
-    const { isArgosrec, argosrecFrames, frames } = get()
+    const { isArgosrec, argosrecFrames, frames, keyframeCache } = get()
     const total = isArgosrec ? argosrecFrames.length : frames.length
     if (idx < 0 || idx >= total) return
 
     stopLoop()
 
     if (isArgosrec) {
-      // Must replay from last schema to build correct state
-      let schemaIdx = 0
-      for (let i = idx; i >= 0; i--) {
-        if (argosrecFrames[i].type === 'schema') { schemaIdx = i; break }
-      }
-      for (let i = schemaIdx; i <= idx; i++) {
-        applyArgosrecFrame(argosrecFrames[i])
+      if (keyframeCache.length > 0) {
+        // Use optimized seek with keyframe cache
+        optimizedSeek(argosrecFrames, keyframeCache, idx)
+      } else {
+        // Full-mode or no cache: frames are self-contained
+        applyArgosrecFrame(argosrecFrames[idx])
       }
     } else {
       useExperimentStore.getState().applyBroadcast(frames[idx].message)

--- a/client-next/src/ui/RecordingControls.tsx
+++ b/client-next/src/ui/RecordingControls.tsx
@@ -1,25 +1,55 @@
-import { useRef, useCallback } from 'react'
+import { useRef, useCallback, useState } from 'react'
 import { useShallow } from 'zustand/shallow'
-import { Circle, Square, Play, Pause, Download, Upload, FileUp } from 'lucide-react'
+import { Circle, Square, Play, Pause, Download, Upload, FileUp, ChevronLeft, ChevronRight } from 'lucide-react'
 import { useRecordingStore } from '@/stores/recordingStore'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Slider } from '@/components/ui/slider'
 
-function Btn({ icon: Icon, label, onClick, variant, className, testId }: {
-  icon: React.ElementType; label: string; onClick: () => void; variant?: 'ghost' | 'default'; className?: string; testId?: string
+function Btn({ icon: Icon, label, onClick, variant, className, testId, disabled }: {
+  icon: React.ElementType; label: string; onClick: () => void; variant?: 'ghost' | 'default'; className?: string; testId?: string; disabled?: boolean
 }) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <Button variant={variant ?? 'ghost'} size="icon" className={`h-6 w-6 ${className ?? ''}`} onClick={onClick} data-testid={testId}>
+        <Button variant={variant ?? 'ghost'} size="icon" className={`h-6 w-6 ${className ?? ''}`} onClick={onClick} data-testid={testId} disabled={disabled}>
           <Icon className="h-3 w-3" />
         </Button>
       </TooltipTrigger>
       <TooltipContent side="bottom"><p>{label}</p></TooltipContent>
     </Tooltip>
   )
+}
+
+function TimelineTooltip({ totalFrames, sliderRef, everyNSteps }: {
+  totalFrames: number; sliderRef: React.RefObject<HTMLDivElement | null>; everyNSteps?: number
+}) {
+  const [hover, setHover] = useState<{ frame: number; x: number } | null>(null)
+
+  const onMove = useCallback((e: React.MouseEvent) => {
+    const el = sliderRef.current
+    if (!el || totalFrames <= 1) return
+    const rect = el.getBoundingClientRect()
+    const pct = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width))
+    const frame = Math.round(pct * (totalFrames - 1))
+    setHover({ frame, x: e.clientX - rect.left })
+  }, [totalFrames, sliderRef])
+
+  const onLeave = useCallback(() => setHover(null), [])
+
+  return {
+    onMove,
+    onLeave,
+    tooltip: hover !== null ? (
+      <div
+        className="absolute -top-7 pointer-events-none bg-popover text-popover-foreground border rounded px-1.5 py-0.5 text-[10px] font-mono whitespace-nowrap z-50"
+        style={{ left: hover.x, transform: 'translateX(-50%)' }}
+      >
+        Frame {hover.frame + 1}{everyNSteps ? ` · Step ${hover.frame * everyNSteps}` : ''}
+      </div>
+    ) : null,
+  }
 }
 
 export function RecordingControls() {
@@ -35,6 +65,9 @@ export function RecordingControls() {
       togglePlayPause: s.togglePlayPause, setSpeed: s.setSpeed, seekTo: s.seekTo,
     })))
   const fileRef = useRef<HTMLInputElement>(null)
+  const sliderRef = useRef<HTMLDivElement>(null)
+
+  const everyNSteps = argosrecHeader?.every_n_steps
 
   const handleFile = useCallback((file: File) => {
     if (file.name.endsWith('.argosrec') || file.name.endsWith('.argosrec.gz')) {
@@ -85,6 +118,35 @@ export function RecordingControls() {
 
   // idle with frames or replaying
   return (
+    <ReplayBar
+      state={state} playing={playing} frameIndex={frameIndex} totalFrames={totalFrames}
+      speed={speed} isArgosrec={isArgosrec} argosrecHeader={argosrecHeader}
+      argosrecWarnings={argosrecWarnings} everyNSteps={everyNSteps}
+      togglePlayPause={togglePlayPause} stopReplay={stopReplay} startReplay={startReplay}
+      startRecording={startRecording} seekTo={seekTo} setSpeed={setSpeed}
+      downloadRecording={downloadRecording} fileRef={fileRef} sliderRef={sliderRef}
+      handleDrop={handleDrop} handleDragOver={handleDragOver} handleFileInput={handleFileInput}
+    />
+  )
+}
+
+function ReplayBar({ state, playing, frameIndex, totalFrames, speed, isArgosrec, argosrecHeader,
+  argosrecWarnings, everyNSteps, togglePlayPause, stopReplay, startReplay, startRecording,
+  seekTo, setSpeed, downloadRecording, fileRef, sliderRef, handleDrop, handleDragOver, handleFileInput,
+}: {
+  state: RecordingState; playing: boolean; frameIndex: number; totalFrames: number
+  speed: number; isArgosrec: boolean; argosrecHeader: import('@/protocol/argosrecParser').ArgosrecHeader | null
+  argosrecWarnings: string[]; everyNSteps?: number
+  togglePlayPause: () => void; stopReplay: () => void; startReplay: () => void
+  startRecording: () => void; seekTo: (idx: number) => void; setSpeed: (s: number) => void
+  downloadRecording: () => void; fileRef: React.RefObject<HTMLInputElement | null>
+  sliderRef: React.RefObject<HTMLDivElement | null>
+  handleDrop: (e: React.DragEvent) => void; handleDragOver: (e: React.DragEvent) => void
+  handleFileInput: (e: React.ChangeEvent<HTMLInputElement>) => void
+}) {
+  const { onMove, onLeave, tooltip } = TimelineTooltip({ totalFrames, sliderRef, everyNSteps })
+
+  return (
     <div
       className="flex items-center gap-1.5 h-7 px-3 border-b bg-card/50"
       onDrop={handleDrop}
@@ -92,7 +154,9 @@ export function RecordingControls() {
     >
       {state === 'replaying' ? (
         <>
-          <Btn icon={playing ? Pause : Play} label={playing ? 'Pause' : 'Play'} onClick={togglePlayPause} />
+          <Btn icon={ChevronLeft} label="Previous frame" onClick={() => seekTo(frameIndex - 1)} disabled={frameIndex <= 0} testId="frame-back-btn" />
+          <Btn icon={playing ? Pause : Play} label={playing ? 'Pause' : 'Play'} onClick={togglePlayPause} testId="play-pause-btn" />
+          <Btn icon={ChevronRight} label="Next frame" onClick={() => seekTo(frameIndex + 1)} disabled={frameIndex >= totalFrames - 1} testId="frame-fwd-btn" />
           <Btn icon={Square} label="Stop Replay" onClick={stopReplay} />
         </>
       ) : (
@@ -101,15 +165,22 @@ export function RecordingControls() {
           <Btn icon={Circle} label="Record" onClick={startRecording} className="text-red-500" testId="record-btn" />
         </>
       )}
-      <Slider
-        value={[frameIndex]}
-        min={0}
-        max={Math.max(totalFrames - 1, 0)}
-        step={1}
-        onValueChange={(v) => seekTo(Array.isArray(v) ? v[0] : v)}
-        className="w-40"
-      />
-      <span className="text-[10px] font-mono text-muted-foreground">{frameIndex + 1}/{totalFrames}</span>
+      <div ref={sliderRef} className="relative flex-1 min-w-0" onMouseMove={onMove} onMouseLeave={onLeave}>
+        {tooltip}
+        <Slider
+          value={[frameIndex]}
+          min={0}
+          max={Math.max(totalFrames - 1, 0)}
+          step={1}
+          onValueChange={(v) => seekTo(Array.isArray(v) ? v[0] : v)}
+          className="w-full"
+          data-testid="timeline-slider"
+        />
+      </div>
+      <span className="text-[10px] font-mono text-muted-foreground whitespace-nowrap" data-testid="frame-display">
+        {frameIndex + 1}/{totalFrames}
+        {everyNSteps ? ` · Step ${frameIndex * everyNSteps}` : ''}
+      </span>
       {isArgosrec && argosrecHeader?.created && (
         <span className="text-[10px] text-muted-foreground truncate max-w-32" title={argosrecHeader.created}>
           {new Date(argosrecHeader.created).toLocaleDateString()}
@@ -119,11 +190,11 @@ export function RecordingControls() {
         <span className="text-[10px] text-yellow-500" title={argosrecWarnings.join('\n')}>⚠</span>
       )}
       <Select value={String(speed)} onValueChange={(v) => setSpeed(Number(v))}>
-        <SelectTrigger className="h-5 w-14 text-[10px]">
+        <SelectTrigger className="h-5 w-14 text-[10px]" data-testid="speed-select">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
-          {[0.5, 1, 2, 4].map((s) => (
+          {[0.5, 1, 2, 4, 8, 16].map((s) => (
             <SelectItem key={s} value={String(s)} className="text-[10px]">{s}x</SelectItem>
           ))}
         </SelectContent>
@@ -134,3 +205,5 @@ export function RecordingControls() {
     </div>
   )
 }
+
+type RecordingState = 'idle' | 'recording' | 'replaying'

--- a/client-next/tests/unit/timelineScrubber.test.ts
+++ b/client-next/tests/unit/timelineScrubber.test.ts
@@ -1,0 +1,258 @@
+import { describe, test, expect, beforeEach } from 'vitest'
+import { useRecordingStore, buildKeyframeCache, computeCacheInterval } from '@/stores/recordingStore'
+import { useExperimentStore } from '@/stores/experimentStore'
+import { makeBroadcast, makeEntity, makeSchema, makeDelta } from '../helpers'
+import type { ArgosrecFrame } from '@/protocol/argosrecParser'
+import type { SchemaMessage, DeltaMessage } from '@/types/protocol'
+
+beforeEach(() => {
+  useRecordingStore.setState({
+    state: 'idle', frames: [], argosrecFrames: [], argosrecHeader: null,
+    argosrecWarnings: [], frameIndex: 0, totalFrames: 0, speed: 1,
+    playing: false, isArgosrec: false, keyframeCache: [], cacheInterval: 200,
+  })
+  useExperimentStore.setState({
+    entities: new Map(), prevEntities: new Map(), computedFields: new Map(),
+    arena: null, drawCommands: [], floorData: null, userData: undefined,
+  })
+})
+
+/** Build a sequence of argosrec frames: 1 schema + N-1 deltas */
+function buildDeltaFrames(entityCount: number, totalFrames: number): ArgosrecFrame[] {
+  const entities = Array.from({ length: entityCount }, (_, i) => makeEntity(`r${i}`, i, 0))
+  const schema: ArgosrecFrame = {
+    type: 'schema', step: 0,
+    message: makeSchema(entities),
+  }
+  const frames: ArgosrecFrame[] = [schema]
+  for (let i = 1; i < totalFrames; i++) {
+    const delta: Record<string, Partial<typeof entities[0]>> = {}
+    delta['r0'] = { position: { x: i * 0.1, y: 0, z: 0 } }
+    frames.push({
+      type: 'delta', step: i,
+      message: makeDelta(delta, i),
+    })
+  }
+  return frames
+}
+
+describe('computeCacheInterval', () => {
+  test('returns 200 for small entity counts', () => {
+    expect(computeCacheInterval(6)).toBe(200)
+    expect(computeCacheInterval(50)).toBe(200)
+    expect(computeCacheInterval(99)).toBe(200)
+  })
+
+  test('scales with entity count above 100', () => {
+    expect(computeCacheInterval(200)).toBe(400)
+    expect(computeCacheInterval(1000)).toBe(2000)
+  })
+})
+
+describe('buildKeyframeCache', () => {
+  test('returns empty for empty frames', () => {
+    expect(buildKeyframeCache([], 200)).toEqual([])
+  })
+
+  test('caches frame 0 (schema)', () => {
+    const frames = buildDeltaFrames(3, 10)
+    const cache = buildKeyframeCache(frames, 5)
+    expect(cache.length).toBe(2) // frame 0 and frame 5
+    expect(cache[0].frameIndex).toBe(0)
+    expect(cache[0].entities.size).toBe(3)
+    expect(cache[1].frameIndex).toBe(5)
+  })
+
+  test('cached snapshots reflect accumulated deltas', () => {
+    const frames = buildDeltaFrames(2, 10)
+    const cache = buildKeyframeCache(frames, 5)
+    // At frame 5, r0 should have position.x = 5 * 0.1 = 0.5
+    const r0 = cache[1].entities.get('r0')!
+    expect((r0 as any).position.x).toBeCloseTo(0.5)
+  })
+
+  test('snapshots are independent (deep cloned)', () => {
+    const frames = buildDeltaFrames(2, 10)
+    const cache = buildKeyframeCache(frames, 5)
+    // Mutating cache[0] should not affect cache[1]
+    cache[0].entities.get('r0')!.id = 'mutated'
+    expect(cache[1].entities.get('r0')!.id).toBe('r0')
+  })
+})
+
+describe('seekTo with keyframe cache', () => {
+  test('seeks to exact frame using cache', () => {
+    const frames = buildDeltaFrames(3, 20)
+    const cache = buildKeyframeCache(frames, 5)
+
+    useRecordingStore.setState({
+      state: 'replaying', argosrecFrames: frames, totalFrames: frames.length,
+      isArgosrec: true, keyframeCache: cache, cacheInterval: 5,
+    })
+
+    useRecordingStore.getState().seekTo(7)
+    expect(useRecordingStore.getState().frameIndex).toBe(7)
+
+    // r0 should have position.x = 7 * 0.1 = 0.7
+    const entities = useExperimentStore.getState().entities
+    const r0 = entities.get('r0')!
+    expect((r0 as any).position.x).toBeCloseTo(0.7)
+  })
+
+  test('seek sets prevEntities from frame target-1', () => {
+    const frames = buildDeltaFrames(2, 10)
+    const cache = buildKeyframeCache(frames, 5)
+
+    useRecordingStore.setState({
+      state: 'replaying', argosrecFrames: frames, totalFrames: frames.length,
+      isArgosrec: true, keyframeCache: cache, cacheInterval: 5,
+    })
+
+    useRecordingStore.getState().seekTo(6)
+    const prev = useExperimentStore.getState().prevEntities
+    const prevR0 = prev.get('r0')!
+    // prevEntities should be from frame 5: position.x = 5 * 0.1 = 0.5
+    expect((prevR0 as any).position.x).toBeCloseTo(0.5)
+  })
+
+  test('seek to frame 0 works', () => {
+    const frames = buildDeltaFrames(2, 10)
+    const cache = buildKeyframeCache(frames, 5)
+
+    useRecordingStore.setState({
+      state: 'replaying', argosrecFrames: frames, totalFrames: frames.length,
+      isArgosrec: true, keyframeCache: cache, cacheInterval: 5,
+    })
+
+    useRecordingStore.getState().seekTo(0)
+    expect(useRecordingStore.getState().frameIndex).toBe(0)
+    expect(useExperimentStore.getState().entities.size).toBe(2)
+  })
+
+  test('seek pauses playback', () => {
+    const frames = buildDeltaFrames(2, 10)
+    const cache = buildKeyframeCache(frames, 5)
+
+    useRecordingStore.setState({
+      state: 'replaying', argosrecFrames: frames, totalFrames: frames.length,
+      isArgosrec: true, keyframeCache: cache, cacheInterval: 5, playing: true,
+    })
+
+    useRecordingStore.getState().seekTo(3)
+    expect(useRecordingStore.getState().playing).toBe(false)
+  })
+
+  test('seek out of bounds is ignored', () => {
+    const frames = buildDeltaFrames(2, 10)
+    useRecordingStore.setState({
+      state: 'replaying', argosrecFrames: frames, totalFrames: frames.length,
+      isArgosrec: true, keyframeCache: [], cacheInterval: 200, frameIndex: 5,
+    })
+
+    useRecordingStore.getState().seekTo(-1)
+    expect(useRecordingStore.getState().frameIndex).toBe(5)
+
+    useRecordingStore.getState().seekTo(100)
+    expect(useRecordingStore.getState().frameIndex).toBe(5)
+  })
+})
+
+describe('full-mode recordings skip cache', () => {
+  test('seekTo works without cache for full-mode frames', () => {
+    const entities = [makeEntity('r0', 0, 0), makeEntity('r1', 1, 1)]
+    const frames: ArgosrecFrame[] = [
+      { type: 'full', step: 0, message: makeBroadcast(entities, 0) },
+      { type: 'full', step: 1, message: makeBroadcast([makeEntity('r0', 5, 5), makeEntity('r1', 6, 6)], 1) },
+    ]
+
+    useRecordingStore.setState({
+      state: 'replaying', argosrecFrames: frames, totalFrames: frames.length,
+      isArgosrec: true, keyframeCache: [], cacheInterval: 200,
+    })
+
+    useRecordingStore.getState().seekTo(1)
+    expect(useRecordingStore.getState().frameIndex).toBe(1)
+    const r0 = useExperimentStore.getState().entities.get('r0')!
+    expect((r0 as any).position.x).toBe(5)
+  })
+})
+
+describe('recording (unchanged behavior)', () => {
+  test('captureFrame ignores when not recording', () => {
+    useRecordingStore.getState().captureFrame(makeBroadcast([]))
+    expect(useRecordingStore.getState().frames.length).toBe(0)
+  })
+
+  test('captureFrame stores frames when recording', () => {
+    useRecordingStore.getState().startRecording()
+    useRecordingStore.getState().captureFrame(makeBroadcast([makeEntity('r0')]))
+    useRecordingStore.getState().captureFrame(makeBroadcast([makeEntity('r0', 1, 1)]))
+    expect(useRecordingStore.getState().frames.length).toBe(2)
+  })
+
+  test('stopRecording sets totalFrames', () => {
+    useRecordingStore.getState().startRecording()
+    useRecordingStore.getState().captureFrame(makeBroadcast([]))
+    useRecordingStore.getState().captureFrame(makeBroadcast([]))
+    useRecordingStore.getState().captureFrame(makeBroadcast([]))
+    useRecordingStore.getState().stopRecording()
+    expect(useRecordingStore.getState().totalFrames).toBe(3)
+    expect(useRecordingStore.getState().state).toBe('idle')
+  })
+})
+
+describe('seekTo for live recordings', () => {
+  test('sets frameIndex within bounds', () => {
+    const frames = [
+      { timestamp: 100, message: makeBroadcast([makeEntity('r0')]) },
+      { timestamp: 200, message: makeBroadcast([makeEntity('r0', 1, 1)]) },
+    ]
+    useRecordingStore.getState().loadRecording(JSON.stringify(frames))
+    useRecordingStore.getState().seekTo(1)
+    expect(useRecordingStore.getState().frameIndex).toBe(1)
+  })
+})
+
+describe('user_data accumulation during seek', () => {
+  test('last user_data is carried through deltas', () => {
+    const schema: ArgosrecFrame = {
+      type: 'schema', step: 0,
+      message: {
+        type: 'schema',
+        arena: { size: { x: 10, y: 10, z: 1 }, center: { x: 0, y: 0, z: 0.5 } },
+        entities: [makeEntity('r0')],
+        user_data: { _draw: [{ shape: 'circle', pos: [0, 0, 0], radius: 1, color: [1, 0, 0, 1], fill: true }] },
+      } as SchemaMessage,
+    }
+    const delta1: ArgosrecFrame = {
+      type: 'delta', step: 1,
+      message: { type: 'delta', steps: 1, entities: { r0: { position: { x: 1, y: 0, z: 0 } } } } as DeltaMessage,
+    }
+    const delta2: ArgosrecFrame = {
+      type: 'delta', step: 2,
+      message: {
+        type: 'delta', steps: 2, entities: { r0: { position: { x: 2, y: 0, z: 0 } } },
+        user_data: { _draw: [{ shape: 'circle', pos: [1, 1, 0], radius: 2, color: [0, 1, 0, 1], fill: false }] },
+      } as DeltaMessage,
+    }
+    const delta3: ArgosrecFrame = {
+      type: 'delta', step: 3,
+      message: { type: 'delta', steps: 3, entities: { r0: { position: { x: 3, y: 0, z: 0 } } } } as DeltaMessage,
+    }
+
+    const frames = [schema, delta1, delta2, delta3]
+    const cache = buildKeyframeCache(frames, 200)
+
+    useRecordingStore.setState({
+      state: 'replaying', argosrecFrames: frames, totalFrames: frames.length,
+      isArgosrec: true, keyframeCache: cache, cacheInterval: 200,
+    })
+
+    // Seek to frame 3 — should carry forward user_data from frame 2
+    useRecordingStore.getState().seekTo(3)
+    const draw = useExperimentStore.getState().drawCommands
+    expect(draw.length).toBe(1)
+    expect(draw[0].shape).toBe('circle')
+    expect((draw[0] as any).radius).toBe(2)
+  })
+})

--- a/docs/designs/PN-018-timeline-scrubber.md
+++ b/docs/designs/PN-018-timeline-scrubber.md
@@ -1,0 +1,107 @@
+# PN-018 Timeline Scrubber — Design
+
+Created: 2026-04-21
+Phase: 🟡 DESIGN
+
+## Overview
+
+Add keyframe-cached seeking and a full-width timeline to make replay
+navigation instant and precise, even for 100k+ frame delta recordings.
+
+## Architecture
+
+### 1. Keyframe Cache (recordingStore.ts)
+
+On `loadArgosrecFile`, after parsing, build a cache of full entity-state
+snapshots at regular intervals. The cache is an array of `KeyframeSnapshot`
+objects stored in the recording store.
+
+```ts
+interface KeyframeSnapshot {
+  frameIndex: number
+  entities: Map<string, AnyEntity>
+  arena: ArenaInfo | null
+  userData: unknown
+}
+```
+
+**Adaptive interval**: `interval = Math.max(200, entityCount * 2)`.
+This caps memory at ~50MB for 1000-entity recordings.
+
+**Skip for full-mode**: If all frames are type `'full'` or `'schema'`,
+no cache is needed — each frame is self-contained.
+
+**Build process** (in `buildKeyframeCache`):
+1. Start from frame 0 (schema). Apply to a local Map (not the store).
+2. Every `interval` frames, deep-clone the Map into the cache.
+3. Track `userData` (last seen) and `arena` (last seen) alongside entities.
+
+### 2. Optimized Seek (recordingStore.ts)
+
+Replace the current `seekTo` with a fast path:
+
+1. Find nearest cached snapshot ≤ target index
+2. Clone that snapshot's entities into a working Map
+3. Replay forward from snapshot to target, applying deltas to the
+   working Map directly (no computeFields, no setState)
+4. At frame `target - 1`, save the Map as `prevEntities`
+5. At frame `target`, call `experimentStore.setState()` once with
+   the final entities, prevEntities, computeFields, drawCommands, etc.
+
+This reduces seek from O(N × N²) to O(interval × N) for the replay
+loop, plus one O(N²) computeFields call at the end.
+
+### 3. Full-Width Timeline (RecordingControls.tsx)
+
+Replace `className="w-40"` on the Slider with `flex-1` so it fills
+available space. Add a relative wrapper for the hover tooltip.
+
+### 4. Frame-Step Buttons (RecordingControls.tsx)
+
+Add `ChevronLeft` / `ChevronRight` icon buttons that call
+`seekTo(frameIndex ± 1)`. Place them flanking the play/pause button.
+
+### 5. Step Display (RecordingControls.tsx)
+
+Show `Frame {idx+1}/{total}` and, if `argosrecHeader.every_n_steps`
+is available, also show `Step {idx * every_n_steps}`.
+
+### 6. Keyboard Shortcuts (useKeyboardShortcuts.ts)
+
+When `recordingStore.state === 'replaying'`, intercept:
+- `Space` → `togglePlayPause()`
+- `ArrowLeft` → `seekTo(frameIndex - 1)`
+- `ArrowRight` → `seekTo(frameIndex + 1)`
+- `Shift+ArrowLeft` → `seekTo(frameIndex - 10)`
+- `Shift+ArrowRight` → `seekTo(frameIndex + 10)`
+
+Fall through to existing live-connection shortcuts when not replaying.
+
+### 7. Extended Speed (RecordingControls.tsx)
+
+Add `8` and `16` to the speed options array.
+
+### 8. Hover Tooltip (RecordingControls.tsx)
+
+Wrap the Slider in a relative container. On `mousemove`, compute
+the hovered frame index from mouse X position relative to the slider.
+Show an absolute-positioned tooltip above the cursor with the frame number.
+
+## Implementation Order
+
+1. `recordingStore.ts` — keyframe cache + optimized seek
+2. `RecordingControls.tsx` — full-width slider, frame-step buttons,
+   step display, extended speeds, hover tooltip
+3. `useKeyboardShortcuts.ts` — replay-mode shortcuts
+4. Tests
+
+## Key Decisions
+
+- **No Web Worker**: Cache build is O(frames/interval × N) — fast enough
+  on main thread for typical recordings.
+- **Clone via structured clone**: `structuredClone(map)` for snapshots.
+  Maps are supported by structuredClone.
+- **Seek pauses playback**: Dragging the slider pauses. User can resume
+  with Space or play button. This matches video player conventions.
+- **Primary label is frame index**: Step number shown as secondary info
+  when `every_n_steps` is available.

--- a/docs/proposals/FUTURE.md
+++ b/docs/proposals/FUTURE.md
@@ -23,19 +23,13 @@ icons floating above each robot.
 
 ## Future
 
-### PN-017: Multi-Experiment Dashboard
-
-**Goal**: Side-by-side viewports for comparing experiments.
-
-**Effort**: ~4 hrs | Medium complexity
-
----
-
 ### PN-018: Timeline Scrubber / Replay Seek
 
 **Goal**: Scrub through recorded simulation history.
 
-**Effort**: ~4 hrs | Medium complexity
+**Status**: 🟣 VERIFICATION — PR open
+
+**Effort**: ~3.5 hrs | Medium complexity
 **Dependencies**: PN-003
 
 ---
@@ -58,11 +52,11 @@ icons floating above each robot.
 | PN-012 | Configurable Defaults | 2026-04-19 |
 | PN-013 | Floating Panels | 2026-04-19 |
 | PN-014 | Speed Control | 2026-04-19 |
+| PN-017 | Multi-Experiment Dashboard | 2026-04-21 |
 
 ## Summary
 
 | PN | Title | Status | Effort |
 |----|-------|--------|--------|
 | PN-015 | HealthWebviz + Status Icons | 📋 Needs discussion | TBD |
-| PN-017 | Multi-Experiment Dashboard | 📋 Future | 4 hr |
 | PN-018 | Timeline Scrubber | 📋 Future | 4 hr |

--- a/docs/proposals/PN-018-timeline-scrubber.md
+++ b/docs/proposals/PN-018-timeline-scrubber.md
@@ -1,0 +1,238 @@
+# Proposal: Timeline Scrubber / Replay Seek
+
+Created: 2026-04-21
+GitHub Issue: N/A
+
+## Status: 🟣 VERIFICATION
+
+## Goal
+
+Replace the minimal replay slider with a full-featured timeline scrubber that
+makes navigating recorded simulations fast and intuitive — especially for long
+recordings (100k+ frames) where the current seek implementation is too slow.
+
+## Scope Boundary
+
+**In scope:**
+- Full-width timeline scrubber UI (replacing the 160px slider)
+- Keyframe caching for O(1)-ish seek performance on delta recordings
+- Frame-step controls (forward/back one frame)
+- Keyboard shortcuts for replay navigation
+- Step/time display during replay
+- Extended speed options (8x, 16x)
+- Hover tooltip showing frame/step on timeline
+
+**Out of scope:**
+- ❌ Modifying the C++ recorder (no periodic keyframe insertion server-side)
+- ❌ Annotations or markers on the timeline
+- ❌ Multi-track timeline (per-entity tracks)
+- ❌ Waveform/sparkline visualization on the timeline
+- ❌ Thumbnail preview on hover (too expensive for 3D)
+
+## Current State
+
+### What exists
+
+| Component | State |
+|-----------|-------|
+| `recordingStore.seekTo(idx)` | Works but O(N) — replays from frame 0 for delta recordings |
+| `RecordingControls.tsx` | Has a `<Slider>` (160px wide), play/pause, stop, speed (0.5–4x) |
+| `argosrecParser.ts` | Loads entire file into `ArgosrecFrame[]` array in memory |
+| `useKeyboardShortcuts` | Only controls live connection (Space, ArrowRight, R) — not replay |
+| Toolbar step counter | Shows live step count, not recording frame position |
+
+### Recording format constraints
+
+The `.argosrec` delta format stores only changed fields per frame. The file
+has exactly **one schema frame** (frame 0) — all subsequent frames are deltas.
+This means:
+
+- **seekTo(N)** must replay frames 0→N sequentially to build correct state
+- For a 144k-frame recording, seeking to the end = 144k `applyDelta()` calls
+- Each call is cheap (~microseconds per entity), but 144k × 6 entities ≈ 50–200ms
+- For 1000-entity recordings: 144k × 1000 ≈ 1–5 seconds (unacceptable)
+
+### Mock server vs real recorder
+
+The mock server inserts keyframes every 100 frames (`KEYFRAME_INTERVAL=100`),
+but the C++ `CWebvizRecorder` does **not**. Real `.argosrec` files from the
+recorder have only one schema. This proposal must solve seek performance
+client-side.
+
+## Problem Analysis
+
+### P1: Seek is O(N) — unusable for long recordings
+
+A researcher loads a 144k-frame recording and drags the slider to 75%.
+The client must replay 108k frames to render that position. This blocks
+the main thread for 100ms–5s depending on entity count.
+
+### P2: Timeline UI is inadequate
+
+The current slider is 160px wide (`w-40`), crammed between buttons. For a
+144k-frame recording, each pixel represents ~900 frames — no precision.
+There's no time/step readout, no frame-step buttons, no keyboard control.
+
+### P3: No keyboard shortcuts for replay
+
+Researchers expect Space=play/pause, Left/Right=step, but these only work
+for the live connection. During replay, the keyboard does nothing.
+
+### P4: Speed range too limited
+
+4x max is insufficient for skimming long recordings. Researchers want 8x
+and 16x to quickly find interesting moments.
+
+## Proposed Solution (High-Level)
+
+### Keyframe Cache (solves P1)
+
+On file load, build an in-memory cache of full entity state snapshots at
+regular intervals (e.g., every 200 frames). Seeking then becomes:
+
+1. Find the nearest cached snapshot ≤ target index
+2. Restore that snapshot to experimentStore
+3. Replay forward from snapshot → target (at most 199 frames)
+
+**Cost**: Memory — one snapshot per interval. For 6 entities × 200 bytes ×
+720 snapshots (144k/200) ≈ 860KB. For 1000 entities ≈ 140MB. The interval
+should be configurable or adaptive based on entity count.
+
+### Full-Width Timeline (solves P2)
+
+Replace the 160px slider with a full-width bar that spans the recording
+controls area. Show:
+- Current position / total frames
+- Simulation step (frame × every_n_steps)
+- Elapsed / remaining (if timing info available)
+- Hover tooltip with frame number
+
+### Keyboard Shortcuts (solves P3)
+
+When in replay mode, intercept:
+- Space → togglePlayPause
+- ArrowLeft → seekTo(idx - 1)
+- ArrowRight → seekTo(idx + 1)
+- Shift+ArrowLeft → seekTo(idx - 10)
+- Shift+ArrowRight → seekTo(idx + 10)
+
+### Extended Speed (solves P4)
+
+Add 8x and 16x to the replay speed selector.
+
+## Assumptions
+
+- [ ] Keyframe cache memory is acceptable (adaptive interval keeps it under ~50MB)
+- [ ] 200-frame replay-forward is fast enough to feel instant (<16ms for typical recordings)
+- [ ] Researchers primarily use delta-mode recordings (full-mode doesn't need caching)
+- [ ] The existing `<Slider>` component from shadcn/ui supports full-width styling
+- [ ] No need for Web Worker — cache building is fast enough on main thread for typical file sizes
+
+## Key File References
+
+| File | Current State | Proposed Change |
+|------|---------------|-----------------|
+| `src/stores/recordingStore.ts` | seekTo replays from last schema | Add keyframe cache, use cached snapshots for seek |
+| `src/ui/RecordingControls.tsx` | 160px slider, minimal controls | Full-width timeline, frame-step buttons, step display |
+| `src/hooks/useKeyboardShortcuts.ts` | Only live controls | Add replay-mode shortcuts |
+| `src/protocol/argosrecParser.ts` | Parses file into frames | Unchanged (cache built post-parse) |
+
+## Dependencies
+
+- **Requires**: PN-003 (Recorder/Replay) — ✅ Complete
+- **Enhanced by**: None
+- **Blocks**: None
+
+## Open Questions
+
+- What's the right cache interval? Fixed (200) or adaptive (based on entity count)?
+- Should the timeline show simulation step or frame index as primary label?
+- Should seeking while playing pause playback, or continue from the new position?
+- Is a "scrubbing" mode needed (live preview while dragging, without committing)?
+
+## Effort Estimate
+
+| Component | Time |
+|-----------|------|
+| Keyframe cache in recordingStore | 1 hour |
+| Full-width timeline UI | 45 min |
+| Frame-step buttons + step display | 20 min |
+| Keyboard shortcuts for replay | 20 min |
+| Extended speed options | 5 min |
+| Hover tooltip on timeline | 30 min |
+| Testing | 30 min |
+| **Total** | **~3.5 hours** |
+
+## Critique Results
+
+**Reviewer:** Kiro (automated)
+**Date:** 2026-04-21
+
+### Verdict: ✅ PASS — Ready for DESIGN with amendments
+
+The investigation correctly identifies the core problems and proposes a sound
+solution. The critique found one critical performance issue (C2) that must be
+addressed in the design, and several clarifications needed.
+
+### Issues Found
+
+| # | Issue | Severity | Resolution |
+|---|-------|----------|------------|
+| C1 | **Adaptive cache interval needed.** Fixed interval=200 uses 360MB for 1000 entities. Must scale with entity count. | 🔴 High | Use `interval = max(200, entityCount × 2)`. Caps memory at ~50MB. |
+| C2 | **computeFields is O(N²) per frame.** `_distance_to_nearest` and `_neighbor_count` iterate all entities for each entity. Replaying 200 frames through `applyDelta` = 200 × N² operations. For 1000 entities = 200M ops (~1-2s). | 🔴 High | Seek must bypass computeFields for intermediate frames. Only compute on final frame. |
+| C3 | **prevEntities needed for final frame.** computeFields uses prevEntities for `_speed` and `_led_changed`. The optimized seek must track entity state at frame idx-1 to pass as prevEntities. | ⚠️ Medium | During replay-forward loop, keep reference to Map at idx-1. |
+| C4 | **user_data accumulation.** Delta frames may include user_data (draw commands, floor data). The seek loop must carry forward the last user_data seen. | ⚠️ Medium | Track last user_data during replay-forward, pass to final setState. |
+| C5 | **Full-mode recordings don't need cache.** When `header.delta === false`, every frame is complete. Seek is already O(1). Cache building is wasted work. | 🟢 Low | Skip cache for non-delta recordings. |
+| C6 | **Live recordings (non-argosrec) unaffected.** Each frame is a full BroadcastMessage. Seek is O(1). No change needed. | 🟢 Low | No action — existing path is correct. |
+| C7 | **Slider component is sufficient.** Native `<input type="range">` with `flex-1` fills available space. No custom component needed for MVP. | 🟢 Low | Use existing Slider, change `w-40` to `flex-1`. |
+
+### Validated Assumptions
+
+| Assumption | Status | Notes |
+|-----------|--------|-------|
+| Keyframe cache memory acceptable | ✅ With adaptive interval | Fixed=200 fails at 1000 entities; adaptive formula solves it |
+| 200-frame replay-forward < 16ms | ✅ With optimized path | Must skip computeFields for intermediate frames |
+| Researchers use delta-mode recordings | ✅ | Default in recorder XML; full-mode is opt-in |
+| Slider supports full-width | ✅ | Just CSS change |
+| No Web Worker needed | ✅ | Cache build is O(N×frames/interval) — fast enough on main thread |
+
+### Amended Scope
+
+The following must be added to the design phase:
+
+1. **Optimized seek path** — new function that applies deltas without
+   computeFields/setState, only triggering a single React update at the end
+2. **Adaptive cache interval** — formula based on entity count from first schema
+3. **Skip cache for full-mode** — detect `header.delta === false` or all-full frames
+4. **prevEntities tracking** — maintain frame idx-1 state during seek loop
+5. **user_data accumulation** — carry forward last user_data through seek
+
+### Summary
+
+The investigation is solid. The key insight (keyframe cache) is correct but
+needs the optimized seek path (C2) to actually deliver <16ms performance.
+Without it, the cache only reduces the problem from O(N) to O(N/interval)
+frames, but each frame is still O(N²) — defeating the purpose for large swarms.
+
+**Recommendation:** Advance to 🟡 DESIGN with C1–C4 incorporated.
+
+## Done When
+
+- [ ] Seeking to any frame in a 144k-frame delta recording completes in <50ms
+- [ ] Timeline scrubber spans full width of the recording controls bar
+- [ ] Frame index and simulation step displayed during replay
+- [ ] Frame-step buttons (back/forward) work
+- [ ] Keyboard shortcuts (Space, Left, Right, Shift+Left, Shift+Right) work during replay
+- [ ] Speed selector includes 8x and 16x options
+- [ ] Hover over timeline shows frame number tooltip
+- [ ] No regression in normal playback or live connection behavior
+
+## Changelog
+
+| Date | Change | Phase |
+|------|--------|-------|
+| 2026-04-21 | Initial investigation: problem analysis, current state audit, scope | 📋 INVESTIGATION |
+| 2026-04-21 | Critique: validated assumptions, found O(N²) computeFields issue, adaptive cache needed | 🔍 CRITIQUE |
+| 2026-04-21 | Design doc: keyframe cache, optimized seek, full-width timeline, keyboard shortcuts | 🟡 DESIGN |
+| 2026-04-21 | Implementation: all features, 17 new tests, build + 70 tests green | 🔵 IMPLEMENTATION |
+| 2026-04-21 | PR opened, ready for review | 🟣 VERIFICATION |

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -52,10 +52,29 @@ See [TEMPLATE.md](TEMPLATE.md) for the standard proposal format.
 
 | PN | Title | Status | Effort | GitHub Issue |
 |----|-------|--------|--------|-------------|
-| PN-017 | [Multi-Experiment Dashboard](PN-017-multi-experiment-dashboard.md) | 🟣 VERIFICATION | ~3h | TBD |
+| PN-018 | [Timeline Scrubber](PN-018-timeline-scrubber.md) | 🟣 VERIFICATION | ~3.5h | — |
+
+## Completed Proposals
+
+| PN | Title | Completed |
+|----|-------|-----------|
+| PN-017 | Multi-Experiment Dashboard | 2026-04-21 |
+| PN-014 | Speed Control | 2026-04-19 |
+| PN-013 | Floating Panels | 2026-04-19 |
+| PN-012 | Configurable Defaults | 2026-04-19 |
+| PN-011 | Entity Body Color | 2026-04-19 |
+| PN-010 | Viewport Polish | 2026-04-19 |
+| PN-009 | Integration Fixes | 2026-04-15 |
+| PN-008 | Draw Primitives | 2026-04-15 |
+| PN-007 | Leo Renderer | 2026-04-14 |
+| PN-006 | Benchmarking & Testing | 2026-04-14 |
+| PN-005 | Computed Fields | 2026-04-14 |
+| PN-004 | Viz System | 2026-04-14 |
+| PN-003 | Recorder / Replay | 2026-04-13 |
+| PN-002 | Delta Protocol | 2026-04-13 |
+| PN-001 | Client-Next Default | 2026-04-13 |
 
 ## Future Proposals
-
 See [FUTURE.md](FUTURE.md) for PN-015, PN-018, and other ideas not yet started.
 
 ## Parity Tracking


### PR DESCRIPTION
## Summary

Adds a full-featured timeline scrubber for replay navigation with keyframe-cached seeking, replacing the minimal 160px slider.

### Changes

**Keyframe Cache** (recordingStore.ts)
- Builds snapshots at adaptive intervals on file load: `max(200, entityCount×2)`
- Optimized seek: restores nearest snapshot, replays forward without computeFields on intermediate frames, single setState at the end
- Tracks prevEntities at frame target-1 for correct computed fields
- Accumulates user_data through delta chain
- Skipped entirely for full-mode recordings (already O(1))

**Timeline UI** (RecordingControls.tsx)
- Full-width slider (`flex-1`) replacing `w-40`
- Frame-step buttons (back/forward)
- Frame index + simulation step display
- Speed selector: 0.5x–16x (added 8x, 16x)
- Hover tooltip showing frame/step number

**Keyboard Shortcuts** (useKeyboardShortcuts.ts)
- Space: play/pause during replay
- Left/Right: step ±1 frame
- Shift+Left/Right: step ±10 frames
- Falls through to live-connection shortcuts when not replaying

### Files

| Modified | New |
|----------|-----|
| `src/stores/recordingStore.ts` | `tests/unit/timelineScrubber.test.ts` |
| `src/ui/RecordingControls.tsx` | `docs/designs/PN-018-timeline-scrubber.md` |
| `src/hooks/useKeyboardShortcuts.ts` | |

### Testing

- 70/70 unit tests pass (17 new in timelineScrubber.test.ts)
- TypeScript + Vite build clean
- Tests cover: cache building, adaptive interval, optimized seek, prevEntities, user_data accumulation, full-mode skip, bounds checking