### PR TITLE
PN-025: Smart User Data Display

### DIFF
--- a/client-next/src/ui/Sidebar.tsx
+++ b/client-next/src/ui/Sidebar.tsx
@@ -9,6 +9,7 @@ import { VizConfigPanel } from './VizConfigPanel'
 import { SpawnPalette } from './SpawnPalette'
 import { useConnectionStore } from '../stores/connectionStore'
 import { useMetadataStore } from '../stores/metadataStore'
+import { UserDataView } from './UserDataView'
 import type { AnyEntity, Vec3, Quaternion } from '../types/protocol'
 
 const fv = (v: Vec3) => `${v.x.toFixed(2)}, ${v.y.toFixed(2)}, ${v.z.toFixed(2)}`
@@ -61,9 +62,9 @@ function Inspector({ entity }: { entity: AnyEntity }) {
         {entity.user_data !== undefined && (
           <div className="pt-1">
             <span className="text-xs text-muted-foreground">User Data</span>
-            <pre className="text-[10px] text-muted-foreground mt-1 bg-muted p-1.5 rounded overflow-auto max-h-24">
-              {JSON.stringify(entity.user_data, null, 2)}
-            </pre>
+            <div className="mt-1">
+              <UserDataView data={entity.user_data} />
+            </div>
           </div>
         )}
       </div>

--- a/client-next/src/ui/UserDataView.tsx
+++ b/client-next/src/ui/UserDataView.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react'
+import { ChevronRight, ChevronDown } from 'lucide-react'
+
+const MAX_DEPTH = 3
+
+function formatScalar(v: unknown): string {
+  if (v === null || v === undefined) return '—'
+  if (typeof v === 'number') return Number.isInteger(v) ? String(v) : v.toFixed(4)
+  if (typeof v === 'boolean') return v ? '✓' : '✗'
+  if (typeof v === 'string') return v
+  return String(v)
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between items-baseline py-px">
+      <span className="text-[10px] text-muted-foreground truncate mr-2">{label}</span>
+      <span className="text-[10px] font-mono text-right">{value}</span>
+    </div>
+  )
+}
+
+function CollapsibleRow({ label, summary, children }: { label: string; summary: string; children: React.ReactNode }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div>
+      <button onClick={() => setOpen(!open)} className="flex items-center gap-0.5 w-full py-px text-left">
+        {open ? <ChevronDown className="h-2.5 w-2.5 text-muted-foreground shrink-0" /> : <ChevronRight className="h-2.5 w-2.5 text-muted-foreground shrink-0" />}
+        <span className="text-[10px] text-muted-foreground truncate mr-2">{label}</span>
+        {!open && <span className="text-[10px] font-mono text-muted-foreground/60 ml-auto">{summary}</span>}
+      </button>
+      {open && <div className="pl-3">{children}</div>}
+    </div>
+  )
+}
+
+function DataNode({ label, value, depth }: { label: string; value: unknown; depth: number }) {
+  if (value === null || value === undefined) return <Row label={label} value="—" />
+
+  if (Array.isArray(value)) {
+    if (depth >= MAX_DEPTH) return <Row label={label} value={`[${value.length} items]`} />
+    return (
+      <CollapsibleRow label={label} summary={`[${value.length}]`}>
+        {value.map((item, i) => <DataNode key={i} label={String(i)} value={item} depth={depth + 1} />)}
+      </CollapsibleRow>
+    )
+  }
+
+  if (typeof value === 'object') {
+    const keys = Object.keys(value)
+    if (depth >= MAX_DEPTH) return <Row label={label} value={`{${keys.length} keys}`} />
+    return (
+      <CollapsibleRow label={label} summary={`{${keys.length}}`}>
+        {keys.map((k) => <DataNode key={k} label={k} value={(value as Record<string, unknown>)[k]} depth={depth + 1} />)}
+      </CollapsibleRow>
+    )
+  }
+
+  return <Row label={label} value={formatScalar(value)} />
+}
+
+export function UserDataView({ data }: { data: unknown }) {
+  if (data === null || data === undefined) return null
+  if (typeof data !== 'object') return <Row label="value" value={formatScalar(data)} />
+
+  const entries = Array.isArray(data)
+    ? data.map((v, i) => [String(i), v] as const)
+    : Object.entries(data as Record<string, unknown>)
+
+  return (
+    <div className="space-y-0">
+      {entries.map(([k, v]) => <DataNode key={k} label={k} value={v} depth={0} />)}
+    </div>
+  )
+}

--- a/client-next/src/ui/panels/EntityDebugPanel.tsx
+++ b/client-next/src/ui/panels/EntityDebugPanel.tsx
@@ -4,6 +4,7 @@ import { FloatingPanel } from '../FloatingPanel'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { ChevronRight } from 'lucide-react'
 import type { AnyEntity, Vec3, Quaternion } from '@/types/protocol'
+import { UserDataView } from '../UserDataView'
 
 export const ENTITY_DEBUG_PANEL_ID = 'entity-debug'
 
@@ -104,9 +105,9 @@ function EntityContent({ entity, computed }: { entity: AnyEntity; computed: Reco
 
       {entity.user_data !== undefined && (
         <Sect title="User Data" defaultOpen={false}>
-          <pre className="text-[9px] text-muted-foreground bg-muted p-1.5 rounded overflow-auto max-h-40">
-            {JSON.stringify(entity.user_data, null, 2)}
-          </pre>
+          <div className="pl-2">
+            <UserDataView data={entity.user_data} />
+          </div>
         </Sect>
       )}
 

--- a/docs/proposals/PN-025-smart-user-data-display.md
+++ b/docs/proposals/PN-025-smart-user-data-display.md
@@ -1,0 +1,128 @@
+# Proposal: Smart User Data Display
+
+Created: 2026-04-26
+Baseline Commit: `7d8eb56` (`master`)
+GitHub Issue: #51
+
+## Status: 🟣 VERIFICATION
+
+## Goal
+
+Replace raw JSON dumps of per-entity `user_data` with auto-discovered, formatted key/value rows in the sidebar inspector and debug panel. Make controller data immediately readable without requiring users to parse JSON visually.
+
+## Scope Boundary
+
+**In scope:**
+- Auto-discover user_data field names from entity data
+- Render scalar fields (number, string, boolean) as formatted rows
+- Render arrays/objects as collapsed summaries with expand-on-click
+- Replace raw JSON dump in sidebar inspector
+- Replace raw JSON dump in debug panel's User Data section
+- Handle missing/changing fields gracefully
+
+**Out of scope:**
+- ❌ C++ side changes — no changes to how data is sent
+- ❌ Global user_data (ExperimentData panel) — already has its own display
+- ❌ Field pinning / watch list (future enhancement)
+- ❌ Time series / charting of values
+
+## Current State
+
+**What exists:**
+- Sidebar inspector: raw `JSON.stringify(entity.user_data, null, 2)` in a `<pre>` block
+- Debug panel: same raw JSON dump in User Data section
+- ExperimentData panel: auto-formats global user_data as key/value rows (good pattern to follow)
+- VizEngine: already discovers user_data field names for color-by selectors
+
+**What's missing:**
+- Per-entity user_data shown as readable rows
+- Collapsed summaries for complex values (arrays, nested objects)
+- No JSON.stringify on every render frame
+
+## Design
+
+### Approach
+
+Create a `UserDataView` component that recursively renders user_data as key/value rows. Use it in both the sidebar inspector and debug panel, replacing the raw JSON `<pre>` blocks.
+
+### Key Decisions
+
+1. **Scalars inline, complex values collapsed** — numbers/strings/booleans show the value directly. Arrays show `[N items]`, objects show `{N keys}`, expandable on click.
+2. **Reuse ExperimentDataPanel's `formatValue`** — same formatting logic for consistency.
+3. **No memoization needed** — only renders for the one selected entity, not all entities.
+4. **Depth limit** — nested expansion capped at 3 levels to prevent runaway rendering.
+
+### Pseudocode / Steps
+
+```
+UserDataView({ data }):
+  if data is null/undefined → show "—"
+  if data is not object → show formatValue(data)
+  for each [key, value] in Object.entries(data):
+    if value is scalar → Row(key, formatValue(value))
+    if value is array → CollapsibleRow(key, `[${value.length} items]`, expanded: UserDataView(value))
+    if value is object → CollapsibleRow(key, `{${Object.keys(value).length} keys}`, expanded: UserDataView(value))
+```
+
+## Key File References
+
+| File | Current State | Change |
+|---|---|---|
+| `client-next/src/ui/UserDataView.tsx` | Does not exist | Create — recursive user_data renderer |
+| `client-next/src/ui/Sidebar.tsx` | Raw JSON dump | Use UserDataView |
+| `client-next/src/ui/panels/EntityDebugPanel.tsx` | Raw JSON dump | Use UserDataView |
+
+## Assumptions
+
+- [x] user_data is always a JSON object or undefined
+- [x] Only one entity's user_data rendered at a time (selected entity)
+- [x] Field names are stable across ticks (same controller sends same fields)
+
+## Dependencies
+
+- **Requires**: None
+- **Enhanced by**: PN-024 (Entity Inspection Panel)
+- **Blocks**: None
+
+## Done When
+
+- [ ] Scalar user_data fields shown as formatted key/value rows
+- [ ] Arrays shown as collapsed `[N items]` with expand
+- [ ] Nested objects shown as collapsed `{N keys}` with expand
+- [ ] Depth limited to 3 levels
+- [ ] Sidebar inspector uses UserDataView instead of raw JSON
+- [ ] Debug panel uses UserDataView instead of raw JSON
+- [ ] Build passes
+
+## Verification Strategy
+
+### Success Criteria
+- Select entity with user_data → see readable rows, not JSON blob
+
+### Test Plan
+| Test | Type | Procedure | Expected Result |
+|------|------|-----------|-----------------|
+| Scalar fields | Visual | Select entity with user_data | Numbers, strings shown as rows |
+| Array field | Visual | Entity with array in user_data | Shows `[N items]`, expands on click |
+| Nested object | Visual | Entity with nested object | Shows `{N keys}`, expands on click |
+| No user_data | Visual | Select box entity | No user data section shown |
+| Build | Automated | `npx vite build` | Clean build |
+
+## Effort Estimate
+
+**Time:** 1-2 FTE-hours
+
+**Change Footprint:**
+
+| Metric | Estimate |
+|--------|----------|
+| Files created | 1 |
+| Files modified | 2 |
+| Lines added/changed | ~80 |
+| Complexity | Low — recursive component, simple logic |
+
+## Changelog
+
+| Date | Change | Phase |
+|------|--------|-------|
+| 2026-04-26 | Initial draft | 📋 INVESTIGATION |


### PR DESCRIPTION
## Summary

Replace raw JSON dumps of per-entity `user_data` with a recursive `UserDataView` component that auto-discovers fields and renders them as readable rows.

**Display rules:**
- Scalars (number, string, boolean) → formatted key/value row
- Arrays → collapsed `[N items]`, click to expand
- Objects → collapsed `{N keys}`, click to expand
- Depth capped at 3 levels
- No `JSON.stringify` on every render frame

## Changes

- `client-next/src/ui/UserDataView.tsx` — new recursive component
- `client-next/src/ui/Sidebar.tsx` — use UserDataView instead of raw JSON
- `client-next/src/ui/panels/EntityDebugPanel.tsx` — use UserDataView instead of raw JSON

## Testing

- Vite build passes, no new TS errors

Closes #51