### PR TITLE
PN-027: README & Documentation Refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,127 +6,110 @@
 
 <br/>
 <p align="center">
-    <a href="https://github.com/NESTLab/argos3-webviz/blob/master/LICENSE" target="_blank">
-        <img src="https://img.shields.io/github/license/NESTLab/argos3-webviz.svg" alt="GitHub license">
+    <a href="https://github.com/dcat52/argos3-webviz/actions/workflows/test.yml">
+        <img src="https://github.com/dcat52/argos3-webviz/actions/workflows/test.yml/badge.svg" alt="Tests">
     </a>
-    <a href="https://github.com/NESTLab/argos3-webviz/releases" target="_blank">
-        <img src="https://img.shields.io/github/tag/NESTLab/argos3-webviz.svg" alt="GitHub tag (latest SemVer)">
+    <a href="https://github.com/dcat52/argos3-webviz/blob/master/LICENSE" target="_blank">
+        <img src="https://img.shields.io/github/license/dcat52/argos3-webviz.svg" alt="GitHub license">
     </a>
-    <a href="https://github.com/NESTLab/argos3-webviz/commits/master" target="_blank">
-        <img src="https://img.shields.io/github/commit-activity/m/NESTLab/argos3-webviz.svg" alt="GitHub commit activity">
-    </a>
-    <img src="https://img.shields.io/github/last-commit/NESTLab/argos3-webviz" alt="GitHub last commit" />
-    <img src="https://visitor-badge.glitch.me/badge?page_id=NESTlab.argos3-webviz" alt="Visitors" />
-    <br>
-    <a href="https://bestpractices.coreinfrastructure.org/projects/3966">
-        <img src="https://bestpractices.coreinfrastructure.org/projects/3966/badge">
-    </a>
-    <a href="https://www.codacy.com/gh/NESTLab/argos3-webviz?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=NESTLab/argos3-webviz&amp;utm_campaign=Badge_Grade">
-        <img src="https://app.codacy.com/project/badge/Grade/0a95aa1f585e403e899710bf626b1f82"/>
-    </a>
+    <img src="https://img.shields.io/github/last-commit/dcat52/argos3-webviz" alt="GitHub last commit" />
 </p>
 <br/>
 
-
 # ARGoS3-Webviz
 
-> **⚠️ Fork Notice:** This is a development fork of [NESTLab/argos3-webviz](https://github.com/NESTLab/argos3-webviz). The `client-next` branch contains experimental work (modern React client, proposals, new features). **Do not push to upstream.** Any upstream contributions are a manual process.
+A web-based visualization and interaction plugin for [ARGoS 3](https://www.argos-sim.info/). Replaces the QT-OpenGL viewer with a browser UI — connect from any machine on the network, no native GUI required.
 
-A Web interface plugin for [ARGoS 3](https://www.argos-sim.info/).
+The project has two parts:
 
-| All builds | Ubuntu 16.04  | Ubuntu 18.04  | Mac OSX |
-|:-:|:-:|:-:|:-:|
-| [![Travis build](https://img.shields.io/travis/com/NESTLab/argos3-webviz)](https://travis-ci.com/NESTLab/argos3-webviz) | [![Ubuntu 16.04 build](https://travis-matrix-badges.herokuapp.com/repos/NESTLab/argos3-webviz/branches/master/1?use_travis_com=true)](https://travis-ci.com/NESTLab/argos3-webviz) | [![Ubuntu 18.04 build](https://travis-matrix-badges.herokuapp.com/repos/NESTLab/argos3-webviz/branches/master/2?use_travis_com=true)](https://travis-ci.com/NESTLab/argos3-webviz) | [![MacOSX build](https://travis-matrix-badges.herokuapp.com/repos/NESTLab/argos3-webviz/branches/master/3?use_travis_com=true)](https://travis-ci.com/NESTLab/argos3-webviz) |
+- **C++ plugin** (`src/`) — ARGoS visualization module that streams simulation state over WebSockets
+- **React client** (`client-next/`) — modern 3D viewer built with React, Three.js / React Three Fiber, and TypeScript
 
 ## Features
 
-![screencast](https://raw.githubusercontent.com/wiki/NESTLab/argos3-webviz/screencast.gif)
+**3D Visualization**
+- Real-time 3D rendering of all standard ARGoS entities (foot-bot, Khepera IV, Leo, box, cylinder, light)
+- LED rendering, sensor ray visualization, draw primitives from loop functions
+- Configurable render tiers (full detail → simplified → points) for large swarms
+- Orthographic and perspective camera modes with FOV control
+- Fit-to-arena viewport on load
 
-- All communication over Websockets
-- SSL support (protocol `wss://`)
-- Only single port needed(Easier for NAT/forwarding/docker)
-- filterable channels (broadcasts, events, logs)
-- easily extendable for custom robots/entities.
-- Independent Web client files.
-- Simple client protocol, can easily be implemented in any technology
-- Using UWebSockets, which is blazing fast([Benchmarks](https://github.com/uNetworking/uWebSockets/blob/master/misc/websocket_lineup.png)).
-- The event-loop is native epoll on Linux, native kqueue on macOS
+**Interaction**
+- Entity selection, inspection panel with live data
+- Entity dragging (Ctrl+click-drag), spawning (click-to-place with drag-to-aim), deletion
+- Keyboard shortcuts for common actions
 
-## See more examples at https://github.com/NESTLab/argos3-webviz-examples
+**Simulation Control**
+- Play / pause / step / fast-forward with configurable speed multipliers
+- Timeline scrubber with keyframe-cached seek
+- Recording and replay
 
+**Data & Protocol**
+- Delta encoding for bandwidth-efficient updates
+- Computed fields and controller state exposure
+- User data display with configurable filtering via `.argos` config
+- Multi-experiment dashboard
+- Floating, resizable panels
 
-## Installing
+**Infrastructure**
+- All communication over WebSockets (single port, NAT/Docker friendly)
+- SSL support (`wss://`)
+- UWebSockets backend (epoll on Linux, kqueue on macOS)
 
-### Dependencies
-#### Homebrew 
+## Quick Start
+
+### C++ Plugin
+
+Install dependencies, then build:
+
 ```console
+# Debian/Ubuntu
+$ sudo apt install cmake git zlib1g-dev libssl-dev
+
+# macOS
 $ brew install cmake git zlib openssl
 ```
-#### Debian
-```console
-$ sudo apt install cmake git zlib1g-dev libssl-dev
-```
-#### Fedora
-```console
-$ sudo dnf install cmake git zlib-devel openssl-devel
-```
-
-You can [Download pre-compiled binaries from Releases](https://github.com/NESTLab/argos3-webviz/releases)
-
-or
-
-<details>
-<summary style="font-size:18px">Installing from source</summary>
-<br>
-
-### Requirements
-- A `UNIX` system (Linux or Mac OSX; Microsoft Windows is not supported)
-- `ARGoS 3`
-- `g++` >= 7 (on Linux)
-- `clang` >= 3.1 (on MacOSX)
-- `cmake` >= 3.5.1
-- `zlib` >= 1.x
-- `git` (for autoinstalling dependencies using Cmake `ExternalProject`)
-
-**Optional dependency**
-- `OpenSSL` >= 1.1 (for websockets over SSL)
-
-Please [install all dependencies](#installing) before continuing
-
-
-### Downloading the source-code
-```console
-$ git clone https://github.com/NESTLab/argos3-webviz
-```
-
-### Compiling
-The compilation is configured through CMake.
 
 ```console
+$ git clone https://github.com/dcat52/argos3-webviz
 $ cd argos3-webviz
-$ mkdir build
-$ cd build
+$ mkdir build && cd build
 $ cmake -DCMAKE_BUILD_TYPE=Release ../src
 $ make
 $ sudo make install
 ```
 
-You can use `-DCMAKE_BUILD_TYPE=Debug` instead of `Release` with the cmake command above to enable debugging.
+### Web Client
 
-</details>
+```console
+$ cd client-next
+$ npm install
+$ npm run mock       # start mock WebSocket server (no ARGoS needed)
+$ npm run dev        # start Vite dev server → http://localhost:5173
+```
 
+See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for the full development guide, stack details, and proposal workflow.
 
-## Contributing
-Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+## Documentation
 
-Please make sure to update tests as appropriate.
-[Check full contributing info](docs/CONTRIBUTING.md)
-
-## License
-[MIT](https://choosealicense.com/licenses/mit/)
-
-Licenses of libraries used are in their respective directories.
-
+- [Basic usage and configuration](docs/basic_usage.md)
+- [Sending data from server to client](docs/sending_data_from_server.md)
+- [Sending data from client to server](docs/sending_data_from_client.md)
+- [Custom entity: server side](docs/custom_entity_serverside.md)
+- [Custom entity: client side](docs/custom_entity_clientside.md)
+- [Writing a custom client](docs/writing_custom_client.md)
+- [Contributing](docs/CONTRIBUTING.md)
 
 ## Limitations
-OpenGL Loop functions are currently neglected in this plugin, as they are QT-OpenGL specific.
+
+- Entity rotation handles not yet implemented (QT-OpenGL has these)
+- Floor texture rendering from loop functions is partial
+- OpenGL loop functions are QT-specific and not applicable to the web client
+
+## License
+
+[MIT](https://choosealicense.com/licenses/mit/)
+
+---
+
+> **Fork notice:** This is a development fork of [NESTLab/argos3-webviz](https://github.com/NESTLab/argos3-webviz). Do not push to upstream. Any upstream contributions are a manual process.

--- a/client-next/README.md
+++ b/client-next/README.md
@@ -1,50 +1,69 @@
-# React + TypeScript + Vite
+# ARGoS3-Webviz Client
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Modern web client for ARGoS3-Webviz. Renders the simulation in 3D, provides entity interaction, and displays live experiment data — all in the browser.
 
-Currently, two official plugins are available:
+## Stack
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- **Vite 5** — build and dev server
+- **React 19** + **TypeScript** (strict)
+- **React Three Fiber** + **Drei** — 3D rendering
+- **Zustand** — state management
+- **Tailwind v4** — styling
+- **Vitest** — unit tests
+- **Playwright** — integration tests
 
-## Expanding the ESLint configuration
+## Development
 
-If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
-
-- Configure the top-level `parserOptions` property like this:
-
-```js
-export default tseslint.config({
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
+```console
+$ npm install
+$ npm run dev          # Vite dev server → http://localhost:5173
 ```
 
-- Replace `tseslint.configs.recommended` to `tseslint.configs.recommendedTypeChecked` or `tseslint.configs.strictTypeChecked`
-- Optionally add `...tseslint.configs.stylisticTypeChecked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and update the config:
+### Mock Server
 
-```js
-// eslint.config.js
-import react from 'eslint-plugin-react'
+Run without ARGoS using the built-in mock WebSocket server:
 
-export default tseslint.config({
-  // Set the react version
-  settings: { react: { version: '18.3' } },
-  plugins: {
-    // Add the react plugin
-    react,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended rules
-    ...react.configs.recommended.rules,
-    ...react.configs['jsx-runtime'].rules,
-  },
-})
+```console
+$ npm run mock         # default scenario
+$ npm run mock:swarm   # swarm scenario
+$ npm run mock:stress  # stress test (many entities)
+$ npm run mock:delta   # delta encoding mode
 ```
+
+See `package.json` for all mock scenarios.
+
+### Testing
+
+```console
+$ npm test                # unit tests (vitest)
+$ npm run test:watch      # unit tests in watch mode
+$ npm run test:integration  # integration tests (playwright)
+```
+
+### Build
+
+```console
+$ npm run build        # type-check + production build
+$ npm run preview      # preview production build
+```
+
+## Project Structure
+
+```
+src/
+  components/ui/   Reusable UI primitives
+  dashboard/       Multi-experiment dashboard
+  entities/        Entity renderers (register in renderers/index.ts)
+  hooks/           Custom React hooks
+  mock/            Mock WebSocket server
+  protocol/        WebSocket message handling
+  scene/           Three.js scene setup
+  stores/          Zustand stores (one per concern)
+  types/           TypeScript type definitions
+  ui/              Application UI (toolbar, panels, sidebar)
+  ui/panels/       Floating panel components
+```
+
+## Contributing
+
+See [docs/CONTRIBUTING.md](../docs/CONTRIBUTING.md) for conventions, branch naming, proposal workflow, and style guides.

--- a/docs/proposals/PN-027-readme-docs-refresh.md
+++ b/docs/proposals/PN-027-readme-docs-refresh.md
@@ -1,0 +1,152 @@
+# Proposal: README & Documentation Refresh
+
+Created: 2026-04-26
+Baseline Commit: `33009b2` (`master`)
+GitHub Issue: #55
+
+## Status: 🟣 VERIFICATION
+<!-- 📋 INVESTIGATION → 🟡 DESIGN → 🔵 IMPLEMENTATION → 🟣 VERIFICATION → ✅ COMPLETE / 🔴 ABANDONED -->
+
+## Goal
+
+Modernize the root README.md and client-next/README.md to reflect the current state of the project — the client-next React client is the primary UI, 26 proposals have shipped, and the old Travis CI / upstream-fork framing is stale. Also clean up minor doc inconsistencies.
+
+## Scope Boundary
+
+**In scope:**
+- Rewrite root `README.md` to reflect client-next as the primary client, current feature set, and updated build/install instructions
+- Replace `client-next/README.md` boilerplate (Vite template) with project-specific content
+- Remove stale Travis CI badge table; replace with current CI or remove entirely
+- Update the Features list to reflect shipped work (inspection panel, entity manipulation, render tiers, etc.)
+- Update Limitations section based on current `PARITY.md`
+
+**Out of scope:**
+- ❌ Changes to `docs/CONTRIBUTING.md` (already comprehensive and up to date)
+- ❌ Changes to `docs/proposals/README.md` or other proposal docs
+- ❌ New screenshots or screencasts (would require a running ARGoS instance)
+- ❌ Changes to any code, config, or build files
+- ❌ Docs under `docs/` other than what's listed above
+
+## Current State
+
+**What exists:**
+- Root `README.md` — references upstream NESTLab repo, Travis CI badges (likely broken), old feature list, old screencast GIF, fork notice. Build instructions reference only the C++ plugin. No mention of client-next.
+- `client-next/README.md` — default Vite "React + TypeScript + Vite" template boilerplate. Not useful.
+- `docs/CONTRIBUTING.md` — already updated with client-next stack, proposal workflow, branch naming. Good shape.
+- `docs/README.md` — docs index, already links proposals and designs. Good shape.
+
+**What's missing:**
+- Root README doesn't mention: React client, entity inspection, manipulation/spawning, render tiers, user data display, timeline scrubber, floating panels, speed control, delta protocol, recording/replay, computed fields, or any of the 26 shipped proposals
+- No quick-start for client-next in root README
+- client-next/README.md has zero project-specific content
+
+## Design
+
+### Approach
+
+Straightforward doc rewrite. No code changes. Two files modified, no new files.
+
+### Key Decisions
+
+1. Keep the fork notice but make it less prominent (move below the main description)
+2. Feature list organized by category (3D visualization, interaction, data, protocol)
+3. Add a "Quick Start" section for client-next development (npm install, mock server, dev server)
+4. Keep C++ build instructions but add client-next build alongside
+5. Remove Travis CI badges — replace with a simple note about CI or remove badge section entirely if no current CI
+6. Link to `docs/CONTRIBUTING.md` for detailed contribution info rather than duplicating
+
+### Pseudocode / Steps
+
+1. Rewrite root `README.md`:
+   - Keep banner image
+   - Update project description to mention both C++ plugin and React client
+   - Replace Travis badges (check if GitHub Actions CI exists first)
+   - New feature list reflecting current capabilities
+   - Quick Start section: C++ plugin build + client-next dev setup
+   - Updated Limitations from PARITY.md
+   - Move fork notice to bottom or make it a smaller note
+2. Rewrite `client-next/README.md`:
+   - Project-specific overview
+   - Dev setup (npm install, mock server, dev)
+   - Stack summary
+   - Link to CONTRIBUTING.md for details
+
+## Key File References
+
+| File | Current State | Change |
+|---|---|---|
+| `README.md` | Stale — references upstream, Travis CI, old features only | Full rewrite reflecting current project |
+| `client-next/README.md` | Vite boilerplate | Rewrite with project-specific dev guide |
+
+## Parameters
+
+| Parameter | Value | Notes |
+|---|---|---|
+| Files modified | 2 | README.md, client-next/README.md |
+| Files created | 0 | |
+
+## Assumptions
+
+- [x] `docs/CONTRIBUTING.md` is up to date and doesn't need changes
+- [x] GitHub Actions CI exists (`.github/workflows/test.yml`) — can add badge
+- [x] Banner image at `client/images/banner_light.png` exists (7KB PNG, 1141x536)
+
+## Dependencies
+
+- **Requires**: None
+- **Enhanced by**: None
+- **Blocks**: None
+
+## Done When
+
+- [ ] Root `README.md` describes client-next as the primary web client
+- [ ] Root `README.md` feature list reflects shipped proposals (entity manipulation, inspection panel, render tiers, user data, timeline, etc.)
+- [ ] Root `README.md` includes quick-start for both C++ build and client-next dev
+- [ ] Root `README.md` has no broken/stale CI badges
+- [ ] `client-next/README.md` has project-specific content (not Vite boilerplate)
+- [ ] All links in both READMEs resolve correctly
+
+## Verification Strategy
+
+### Success Criteria
+- Both READMEs accurately describe the current project state
+- No broken links or references to nonexistent files
+
+### Regression Checks
+- No code, config, or build files changed
+
+### Test Plan
+| Test | Type | Procedure | Expected Result |
+|------|------|-----------|-----------------|
+| Link check | Manual | Verify all markdown links resolve | No 404s |
+| Accuracy check | Manual | Compare feature list against PARITY.md and completed proposals | All major features mentioned |
+| No code changes | Automated | `git diff --stat` shows only .md files | Only README.md and client-next/README.md changed |
+
+### Acceptance Threshold
+- Human review confirms READMEs are accurate and readable
+
+## Effort Estimate
+
+**Time:** 1 FTE-hour
+
+**Change Footprint:**
+
+| Metric | Estimate |
+|--------|----------|
+| Files created | 0 |
+| Files modified | 2 |
+| Lines added/changed | ~150 |
+| Complexity | Low — documentation only, no code |
+
+## Related Proposals
+
+| Idea | Discovered During | Status |
+|------|------------------|--------|
+| — | — | — |
+
+## Changelog
+
+| Date | Change | Workflow |
+|------|--------|---------|
+| 2026-04-26 | Initial draft | proposal-lifecycle |
+| 2026-04-26 | Investigation → Design → Implementation → Verification | proposal-lifecycle |


### PR DESCRIPTION
## Summary

Modernizes both READMEs to reflect the current state of the project after 26 shipped proposals.

### Changes

**`README.md`** (root)
- Replaced stale Travis CI badges with GitHub Actions badge
- Rewrote feature list to cover all shipped work: entity manipulation, inspection panel, render tiers, user data display/filtering, timeline scrubber, delta protocol, recording/replay, floating panels, speed control, etc.
- Added Quick Start section covering both C++ plugin build and client-next dev setup
- Updated Limitations section from current PARITY.md
- Moved fork notice to bottom (less prominent, still present)
- Cleaned up doc links section

**`client-next/README.md`**
- Replaced Vite boilerplate with project-specific content
- Stack summary, dev setup, mock server scenarios, testing commands
- Project structure overview
- Link to CONTRIBUTING.md

### What was NOT changed
- No code, config, or build files
- `docs/CONTRIBUTING.md` unchanged (already up to date)
- No other docs modified

### Verification
- All markdown links verified to resolve
- `git diff --stat` confirms only .md files changed

Closes #55