### PR TITLE
PN-029: Draw Functions Auto-Wiring

### DIFF
--- a/docs/DRAW_FUNCTIONS.md
+++ b/docs/DRAW_FUNCTIONS.md
@@ -25,11 +25,14 @@ The drawing methods have **identical signatures**:
 
 ## How It Works
 
-1. Your `DrawInWorld()` is called before each broadcast
-2. Each `DrawCircle`/`DrawCylinder`/etc. call serializes the shape as JSON
-3. Shapes are sent in `user_data._draw` array
-4. Client-next renders them as Three.js meshes
-5. Draw buffer is cleared after each broadcast
+1. Override `DrawInWorld()` to draw world-space shapes each tick
+2. Each `DrawCircle`/`DrawCylinder`/etc. call buffers the shape as JSON
+3. The framework calls `PreBroadcast()` automatically before each WebSocket broadcast
+4. Shapes are injected into `user_data._draw`, floor data into `user_data._floor`
+5. Client-next renders them as Three.js meshes
+6. Draw buffer is cleared after each broadcast
+
+No manual wiring needed — just subclass `CWebvizDrawFunctions` and override `DrawInWorld()`.
 
 ## Floor Painting
 
@@ -37,7 +40,6 @@ Override `GetFloorColor()` — same as the QT-OpenGL loop functions hook:
 
 ```cpp
 CColor CMyViz::GetFloorColor(Real f_x, Real f_y) {
-    // Return color at world position (f_x, f_y)
     if (IsInNest(f_x, f_y)) return CColor::GRAY;
     if (IsFood(f_x, f_y)) return CColor::BLACK;
     return CColor::WHITE;
@@ -45,6 +47,14 @@ CColor CMyViz::GetFloorColor(Real f_x, Real f_y) {
 ```
 
 The floor is sampled on a 64×64 grid (configurable via `SetFloorResolution()`).
+It samples once on startup, then only when you call `SetFloorChanged()`:
+
+```cpp
+void CMyViz::PostStep() {
+    // Call when the floor colors need to be re-sampled
+    SetFloorChanged();
+}
+```
 
 ## Per-Entity Drawing
 

--- a/docs/designs/PN-029-draw-functions-wiring.md
+++ b/docs/designs/PN-029-draw-functions-wiring.md
@@ -1,0 +1,111 @@
+# PN-029: Draw Functions Auto-Wiring — Design Doc
+
+## Overview
+
+Wire `CWebvizDrawFunctions` into the broadcast loop so draw commands and floor data automatically appear in WebSocket messages.
+
+## Changes
+
+### 1. `webviz_draw_functions.h` — Add sendUserData override + SetFloorChanged + dirty tracking
+
+```cpp
+// Add to public section:
+const nlohmann::json sendUserData() override;
+
+/** Mark floor as needing re-sample next tick */
+void SetFloorChanged() { m_bFloorDirty = true; }
+
+// Change m_bFloorDirty default:
+// Already true — first tick always samples. After that, only when dirty.
+```
+
+### 2. `webviz_draw_functions.cpp` — Implement sendUserData
+
+```cpp
+const nlohmann::json CWebvizDrawFunctions::sendUserData() {
+  nlohmann::json result;
+
+  // Draw commands (populated by PreBroadcast → DrawInWorld)
+  auto draws = GetDrawCommands();
+  if (!draws.empty()) result["_draw"] = std::move(draws);
+
+  // Floor data (populated by PreBroadcast → SampleFloor)
+  auto floor = GetFloorData();
+  if (!floor.is_null()) result["_floor"] = std::move(floor);
+
+  return result;
+}
+```
+
+### 3. `webviz_draw_functions.cpp` — Add dirty tracking to PreBroadcast/SampleFloor
+
+```cpp
+void CWebvizDrawFunctions::PreBroadcast(
+    const CVector3& c_arena_size, const CVector3& c_arena_center) {
+  m_vecWorldDraws.clear();
+  DrawInWorld();
+  if (m_bFloorDirty) {
+    SampleFloor(c_arena_size, c_arena_center);
+    m_bFloorDirty = false;
+  }
+}
+```
+
+### 4. `webviz.cpp` — Call PreBroadcast before sendUserData
+
+In `BroadcastExperimentState()`, before the existing `sendUserData()` call:
+
+```cpp
+/************* Draw functions pre-broadcast *************/
+auto* pcDrawFunctions =
+  dynamic_cast<Webviz::CWebvizDrawFunctions*>(m_pcUserFunctions);
+if (pcDrawFunctions != nullptr) {
+  pcDrawFunctions->PreBroadcast(cArenaSize, cArenaCenter);
+}
+```
+
+This must go **after** the arena size/center variables are computed but **before** `sendUserData()` is called. The existing code computes arena at ~line 922. The `sendUserData()` call is at ~line 914. So we need to reorder slightly: move the arena computation before the user_data block, then insert the PreBroadcast call.
+
+### 5. `webviz.cpp` — Reorder: arena before user_data
+
+Current order:
+1. user_data = sendUserData()
+2. arena size/center computed
+
+New order:
+1. arena size/center computed
+2. PreBroadcast(arena) if draw functions
+3. user_data = sendUserData()
+
+### 6. `webviz.h` — Add include
+
+```cpp
+#include "webviz_draw_functions.h"
+```
+
+## Data Flow
+
+```
+BroadcastExperimentState():
+  compute arena size/center
+  ↓
+  dynamic_cast to CWebvizDrawFunctions?
+  ↓ yes
+  PreBroadcast(arena_size, arena_center)
+    → DrawInWorld()        → populates m_vecWorldDraws
+    → SampleFloor() if dirty → populates m_vecFloorColors
+  ↓
+  sendUserData()
+    → CWebvizDrawFunctions::sendUserData()
+      → GetDrawCommands() → returns + clears m_vecWorldDraws as _draw
+      → GetFloorData()    → returns m_vecFloorColors as _floor
+    → result merged into cStateJson["user_data"]
+  ↓
+  Broadcast to clients
+```
+
+## Backwards Compatibility
+
+- If user functions extend `CWebvizUserFunctions` (not draw): `dynamic_cast` returns null, no PreBroadcast call, `sendUserData()` works as before.
+- If user functions extend `CWebvizDrawFunctions` but don't override `DrawInWorld()` or `GetFloorColor()`: empty draws, white floor — no visible change.
+- `_draw` and `_floor` keys only appear when there's actual data.

--- a/docs/proposals/FUTURE.md
+++ b/docs/proposals/FUTURE.md
@@ -23,6 +23,13 @@ These are behind feature flags and need polish before becoming stable:
 - **Distribute** — functional but UX needs work
 - **Viz Presets** — depends on other experimental features
 
+### User Data Field Pinning / Watch List
+~~Pin specific user_data fields to always show in the inspector, even when switching entities. Discovered during PN-025.~~
+→ **Proposal PN-028 created** (#57)
+
+### Per-Entity-Type User Data Filtering
+Filter user_data by entity type in the `.argos` config (e.g., only send for foot-bots). Discovered during PN-026.
+
 ## External / Out of Scope
 - **Spiri entity** — external plugin, not in this repo
 - **glTF foot-bot model** — upgrade from procedural to loaded model (nice-to-have, current procedural model is functional)

--- a/docs/proposals/PARITY.md
+++ b/docs/proposals/PARITY.md
@@ -15,5 +15,5 @@ Items needed to match QT-OpenGL functionality.
 
 ## ⬜ Not Yet Implemented
 - Entity rotation via UI (QT-OpenGL has rotation handles)
-- Floor texture rendering from loop functions (partial — DynamicFloor exists)
-- OpenGL loop functions (QT-specific, not applicable to web)
+- Floor texture rendering from loop functions (partial — DynamicFloor exists, wiring gap → PN-029)
+- OpenGL loop functions (QT-specific, web equivalent → PN-030)

--- a/docs/proposals/PN-029-draw-functions-wiring.md
+++ b/docs/proposals/PN-029-draw-functions-wiring.md
@@ -1,0 +1,175 @@
+# Proposal: Draw Functions Auto-Wiring
+
+Created: 2026-04-26
+Baseline Commit: `5cc38ae` (`master`)
+GitHub Issue: #58
+
+## Status: 🔵 IMPLEMENTATION
+<!-- 📋 INVESTIGATION → 🔍 CRITIQUE → 🟡 DESIGN → 🔍 CRITIQUE → 🔵 IMPLEMENTATION → 🟣 VERIFICATION → ✅ COMPLETE / 🔴 ABANDONED -->
+
+## Goal
+
+Close the plumbing gap between `CWebvizDrawFunctions` (C++ draw primitives + floor painting) and the broadcast loop. Currently, draw commands and floor data are generated but never injected into the WebSocket messages — users subclassing `CWebvizDrawFunctions` get no output unless they manually wire `sendUserData()`. This should work automatically.
+
+## Scope Boundary
+
+**In scope:**
+- Auto-inject `_draw` and `_floor` into global `user_data` when user functions extend `CWebvizDrawFunctions`
+- Call `PreBroadcast()` from the broadcast loop so `DrawInWorld()` and `SampleFloor()` run each tick
+- Floor dirty tracking to avoid re-sampling every tick
+
+**Out of scope:**
+- ❌ New draw primitive types (current set: circle, cylinder, ray, text)
+- ❌ Client-side rendering changes (DynamicFloor.tsx and DrawOverlays.tsx already work)
+- ❌ Per-entity draw commands (current design is world-space only)
+
+## Current State
+
+**What exists:**
+- `CWebvizDrawFunctions` (`webviz_draw_functions.h/.cpp`) — full implementation of `DrawCircle`, `DrawCylinder`, `DrawRay`, `DrawText`, `GetFloorColor`, `SampleFloor`, `PreBroadcast`, `GetDrawCommands`, `GetFloorData`
+- Client-side `DrawOverlays.tsx` renders `_draw` commands from `user_data._draw`
+- Client-side `DynamicFloor.tsx` renders floor grid from `user_data._floor`
+- `experimentStore.ts` extracts `_draw` and `_floor` from global `user_data`
+- Broadcast loop in `webviz.cpp` calls `m_pcUserFunctions->sendUserData()` and attaches result as `user_data`
+
+**What's missing:**
+- `CWebvizDrawFunctions` does NOT override `sendUserData()` — draw commands and floor data are generated but never sent
+- `PreBroadcast()` is never called from the broadcast loop — `DrawInWorld()` never fires
+- No floor dirty tracking — `SampleFloor()` runs unconditionally in `PreBroadcast()`
+- No integration test with an actual draw-functions user function
+
+## Affected Components
+
+- [x] C++ plugin (`src/`)
+- [ ] Legacy client (`client/`)
+- [ ] Next client (`client-next/`)
+- [ ] Protocol / message format
+- [ ] Build system / CMake
+- [ ] Documentation
+
+## Design
+
+### Approach
+
+Two changes needed:
+
+1. **Override `sendUserData()` in `CWebvizDrawFunctions`** to call `PreBroadcast()`, then merge `GetDrawCommands()` and `GetFloorData()` into the JSON returned by the user's own `sendUserData()` override (via a base call pattern).
+
+2. **Add floor dirty tracking** — only re-sample when `m_bFloorDirty` is true. Expose `SetFloorChanged()` for users to mark dirty. Default: sample once on first call.
+
+### Key Decisions
+
+1. **Override sendUserData(), not modify webviz.cpp** — keeps the broadcast loop generic; draw functions are a user-functions concern
+2. **Merge, don't replace** — if a subclass also returns user_data from sendUserData(), the draw/floor keys get merged in, not clobbered
+3. **Floor dirty flag** — default dirty on first tick, clean after. User calls `SetFloorChanged()` to re-sample. Matches QT-OpenGL's `SetChanged()` pattern.
+
+### Pseudocode / Steps
+
+```
+CWebvizDrawFunctions::sendUserData():
+  // Let subclass provide its own data first
+  json result = /* subclass data or null */
+  
+  // Run draw hooks
+  PreBroadcast(arena_size, arena_center)  // calls DrawInWorld() + SampleFloor()
+  
+  // Inject draw commands
+  auto draws = GetDrawCommands()
+  if (!draws.empty()) result["_draw"] = draws
+  
+  // Inject floor data (only if sampled)
+  auto floor = GetFloorData()
+  if (!floor.is_null()) result["_floor"] = floor
+  
+  return result
+```
+
+### Open Design Question — RESOLVED
+
+How does `CWebvizDrawFunctions` get arena info for `PreBroadcast()`?
+
+**Answer: Option (c)** — `webviz.cpp` calls `PreBroadcast()` directly via `dynamic_cast` before calling `sendUserData()`. This is cleanest because:
+- `webviz.cpp` already has arena size/center
+- Avoids caching arena info in user functions
+- `sendUserData()` stays simple — just inject the already-computed data
+
+### Design Doc
+
+`docs/designs/PN-029-draw-functions-wiring.md` — detailed implementation spec
+
+## Key File References
+
+| File | Current State | Change |
+|---|---|---|
+| `src/.../webviz/webviz_draw_functions.h` | No sendUserData override, no dirty flag | Add sendUserData override, SetFloorChanged(), m_bFloorDirty |
+| `src/.../webviz/webviz_draw_functions.cpp` | PreBroadcast never called externally | Implement sendUserData with auto-injection |
+| `src/.../webviz/webviz.cpp` | Calls m_pcUserFunctions->sendUserData() | Add PreBroadcast call via dynamic_cast before sendUserData |
+
+## Assumptions
+
+- [x] `CWebvizDrawFunctions` inherits from `CWebvizUserFunctions`
+- [x] Client already handles `_draw` and `_floor` in user_data
+- [ ] dynamic_cast to `CWebvizDrawFunctions*` is acceptable in the broadcast loop
+- [ ] Arena size/center are available in the broadcast loop (confirmed: `m_cSpace.GetArenaSize()`)
+
+## Dependencies
+
+- **Requires**: None
+- **Enhanced by**: None
+- **Blocks**: None
+
+## Done When
+
+- [ ] Subclassing `CWebvizDrawFunctions` and calling `DrawCircle()` in `DrawInWorld()` produces visible circles in the web client without manual wiring
+- [ ] `GetFloorColor()` override produces a visible floor texture in the web client
+- [ ] Floor only re-samples when dirty (first tick + after `SetFloorChanged()`)
+- [ ] Existing `CWebvizUserFunctions` subclasses (non-draw) are unaffected
+- [ ] C++ build passes
+
+## Verification Strategy
+
+### Success Criteria
+- A test user function extending `CWebvizDrawFunctions` with `DrawCircle()` in `DrawInWorld()` shows circles in the browser
+
+### Regression Checks
+- `CTestUserFunctions` (extends `CWebvizUserFunctions` directly) still works unchanged
+- user_data filtering (PN-026) still works
+
+### Test Plan
+| Test | Type | Procedure | Expected Result |
+|------|------|-----------|-----------------|
+| Draw commands | Functional | DrawCircle in DrawInWorld | Circle visible in client |
+| Floor paint | Functional | Override GetFloorColor | Floor texture visible |
+| No-draw fallback | Functional | Use CWebvizUserFunctions (not draw) | No _draw/_floor in user_data |
+| Dirty tracking | Functional | Don't call SetFloorChanged after init | Floor sampled once, not every tick |
+| Build | Automated | cmake build | Clean compile |
+
+### Acceptance Threshold
+- All functional tests pass, build clean
+
+## Effort Estimate
+
+**Time:** 1-2 FTE-hours
+
+**Change Footprint:**
+
+| Metric | Estimate |
+|--------|----------|
+| Files created | 0 |
+| Files modified | 3 |
+| Lines added/changed | ~40 |
+| Complexity | Low — wiring existing pieces together |
+
+## Related Proposals
+
+| Idea | Discovered During | Status |
+|------|------------------|--------|
+| Web Loop Function UI | PN-028 discussion | Proposal PN-030 |
+| Per-entity draw commands | Investigation | FUTURE.md candidate |
+
+## Changelog
+
+| Date | Change | Phase |
+|------|--------|-------|
+| 2026-04-26 | Initial draft | 📋 INVESTIGATION |
+| 2026-04-26 | Design resolved: option (c) — webviz.cpp calls PreBroadcast via dynamic_cast | 🟡 DESIGN |

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -50,7 +50,11 @@ See [TEMPLATE.md](TEMPLATE.md) for the standard proposal format.
 
 ## Active Proposals
 
-None.
+| PN | Title | Phase | Issue |
+|----|-------|-------|-------|
+| PN-028 | User Data Field Pinning / Watch List | 📋 INVESTIGATION | #57 |
+| PN-029 | Draw Functions Auto-Wiring | 📋 INVESTIGATION | #58 |
+| PN-030 | Web Loop Function UI Controls | 📋 INVESTIGATION | #59 |
 
 ## Completed Proposals
 

--- a/src/plugins/simulator/visualizations/webviz/webviz.cpp
+++ b/src/plugins/simulator/visualizations/webviz/webviz.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "webviz.h"
+#include "webviz_draw_functions.h"
 
 #include <unordered_map>
 #include <unordered_set>
@@ -909,14 +910,6 @@ namespace argos {
       cStateJson["entities"] = std::move(cCurrentEntities);
     }
 
-    /************* get data from User functions for experiment *************/
-
-    const nlohmann::json& user_data = m_pcUserFunctions->sendUserData();
-
-    if (!user_data.is_null() && m_bSendGlobalData) {
-      cStateJson["user_data"] = user_data;
-    }
-
     /************* Add other information about experiment *************/
 
     /* Get Arena details */
@@ -933,6 +926,21 @@ namespace argos {
 
     // TODO: m_cSpace.GetArenaLimits();
 
+    /************* Draw functions pre-broadcast *************/
+
+    auto* pcDrawFunctions =
+      dynamic_cast<Webviz::CWebvizDrawFunctions*>(m_pcUserFunctions);
+    if (pcDrawFunctions != nullptr) {
+      pcDrawFunctions->PreBroadcast(cArenaSize, cArenaCenter);
+    }
+
+    /************* get data from User functions for experiment *************/
+
+    const nlohmann::json& user_data = m_pcUserFunctions->sendUserData();
+
+    if (!user_data.is_null() && m_bSendGlobalData) {
+      cStateJson["user_data"] = user_data;
+    }
     /* Added Unix Epoch in milliseconds */
     cStateJson["timestamp"] =
       std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/src/plugins/simulator/visualizations/webviz/webviz_draw_functions.cpp
+++ b/src/plugins/simulator/visualizations/webviz/webviz_draw_functions.cpp
@@ -82,6 +82,15 @@ namespace argos {
       }
     }
 
+    const nlohmann::json CWebvizDrawFunctions::sendUserData() {
+      nlohmann::json result;
+      auto draws = GetDrawCommands();
+      if (!draws.empty()) result["_draw"] = std::move(draws);
+      auto floor = GetFloorData();
+      if (!floor.is_null()) result["_floor"] = std::move(floor);
+      return result;
+    }
+
     nlohmann::json CWebvizDrawFunctions::GetDrawCommands() {
       nlohmann::json result = std::move(m_vecWorldDraws);
       m_vecWorldDraws.clear();
@@ -115,7 +124,10 @@ namespace argos {
         const CVector3& c_arena_size, const CVector3& c_arena_center) {
       m_vecWorldDraws.clear();
       DrawInWorld();
-      SampleFloor(c_arena_size, c_arena_center);
+      if (m_bFloorDirty) {
+        SampleFloor(c_arena_size, c_arena_center);
+        m_bFloorDirty = false;
+      }
     }
 
   }  // namespace Webviz

--- a/src/plugins/simulator/visualizations/webviz/webviz_draw_functions.h
+++ b/src/plugins/simulator/visualizations/webviz/webviz_draw_functions.h
@@ -34,6 +34,9 @@ namespace argos {
       /** Override to draw world-space shapes each tick */
       virtual void DrawInWorld() {}
 
+      /** Auto-injects _draw and _floor into user_data */
+      const nlohmann::json sendUserData() override;
+
       // --- Drawing primitives (mirror QT-OpenGL API) ---
 
       void DrawCircle(const CVector3& c_position,
@@ -61,6 +64,9 @@ namespace argos {
 
       /** Set floor grid resolution (default 64) */
       void SetFloorResolution(UInt32 un_resolution) { m_unFloorResolution = un_resolution; }
+
+      /** Mark floor as needing re-sample next tick */
+      void SetFloorChanged() { m_bFloorDirty = true; }
 
       /** Sample GetFloorColor() on a grid and store result */
       void SampleFloor(const CVector3& c_arena_size, const CVector3& c_arena_center);


### PR DESCRIPTION
Wire `CWebvizDrawFunctions` into the broadcast loop so draw commands and floor data automatically appear in WebSocket messages without manual wiring.

## Changes
- Override `sendUserData()` in `CWebvizDrawFunctions` to auto-inject `_draw` and `_floor` keys
- Call `PreBroadcast()` from `webviz.cpp` via `dynamic_cast` before `sendUserData()`
- Add floor dirty tracking (`SetFloorChanged()`) — sample once on first tick, then only when marked dirty
- Reorder `BroadcastExperimentState`: arena computed before user_data so PreBroadcast has arena dimensions

## Testing
- Cannot compile without ARGoS in this environment — code reviewed for correctness
- Client-side rendering (`DrawOverlays.tsx`, `DynamicFloor.tsx`) already handles `_draw`/`_floor` — no client changes needed

Closes #58