### PR TITLE
PN-028: User Data Field Pinning / Watch List

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The project has two parts:
 **Interaction**
 - Entity selection, inspection panel with live data
 - Entity dragging (Ctrl+click-drag), spawning (click-to-place with drag-to-aim), deletion
+- Pin user_data fields to a watch list that persists across entity selection
 - Keyboard shortcuts for common actions
 
 **Simulation Control**

--- a/client-next/src/stores/experimentStore.ts
+++ b/client-next/src/stores/experimentStore.ts
@@ -17,6 +17,19 @@ function extractFloor(userData: unknown): FloorColorGrid | null {
   return f
 }
 
+export type PinnedField = { entityId: string; field: string }
+
+function loadPinnedFields(): PinnedField[] {
+  try {
+    const raw = localStorage.getItem('webviz-pinned-fields')
+    return raw ? JSON.parse(raw) : []
+  } catch { return [] }
+}
+
+function savePinnedFields(pins: PinnedField[]) {
+  localStorage.setItem('webviz-pinned-fields', JSON.stringify(pins))
+}
+
 interface ExperimentState_ {
   state: ExperimentState
   steps: number
@@ -32,6 +45,10 @@ interface ExperimentState_ {
   selectedEntityId: string | null
   dragEntityId: string | null
   debugPinnedIds: Set<string>
+  pinnedFields: PinnedField[]
+  pinField: (entityId: string, field: string) => void
+  unpinField: (entityId: string, field: string) => void
+  isFieldPinned: (entityId: string, field: string) => boolean
   applyBroadcast: (msg: BroadcastMessage) => void
   applySchema: (msg: SchemaMessage) => void
   applyDelta: (msg: DeltaMessage) => void
@@ -59,6 +76,25 @@ export const useExperimentStore = create<ExperimentState_>((set, get) => ({
   selectedEntityId: null,
   dragEntityId: null,
   debugPinnedIds: new Set(),
+  pinnedFields: loadPinnedFields(),
+
+  pinField: (entityId, field) => {
+    const pins = get().pinnedFields
+    if (pins.some(p => p.entityId === entityId && p.field === field)) return
+    const next = [...pins, { entityId, field }]
+    savePinnedFields(next)
+    set({ pinnedFields: next })
+  },
+
+  unpinField: (entityId, field) => {
+    const next = get().pinnedFields.filter(p => !(p.entityId === entityId && p.field === field))
+    savePinnedFields(next)
+    set({ pinnedFields: next })
+  },
+
+  isFieldPinned: (entityId, field) => {
+    return get().pinnedFields.some(p => p.entityId === entityId && p.field === field)
+  },
 
   applyBroadcast: (msg) => {
     const prev = get().entities

--- a/client-next/src/ui/PanelLayer.tsx
+++ b/client-next/src/ui/PanelLayer.tsx
@@ -1,6 +1,7 @@
 import { ExperimentDataPanel } from './panels/ExperimentDataPanel'
 import { EventLogPanel } from './panels/EventLogPanel'
 import { EntityDebugPanel } from './panels/EntityDebugPanel'
+import { WatchListPanel } from './panels/WatchListPanel'
 
 export function PanelLayer() {
   return (
@@ -8,6 +9,7 @@ export function PanelLayer() {
       <ExperimentDataPanel />
       <EventLogPanel />
       <EntityDebugPanel />
+      <WatchListPanel />
     </div>
   )
 }

--- a/client-next/src/ui/UserDataView.tsx
+++ b/client-next/src/ui/UserDataView.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { ChevronRight, ChevronDown } from 'lucide-react'
+import { ChevronRight, ChevronDown, Pin } from 'lucide-react'
 
 const MAX_DEPTH = 3
 
@@ -11,11 +11,20 @@ function formatScalar(v: unknown): string {
   return String(v)
 }
 
-function Row({ label, value }: { label: string; value: string }) {
+function Row({ label, value, onPin, pinned }: { label: string; value: string; onPin?: () => void; pinned?: boolean }) {
   return (
-    <div className="flex justify-between items-baseline py-px">
+    <div className="flex items-baseline py-px group/row">
       <span className="text-[10px] text-muted-foreground truncate mr-2">{label}</span>
-      <span className="text-[10px] font-mono text-right">{value}</span>
+      <span className="text-[10px] font-mono text-right ml-auto">{value}</span>
+      {onPin && (
+        <button
+          onClick={onPin}
+          className={`ml-1 shrink-0 ${pinned ? 'text-yellow-500' : 'text-muted-foreground/0 group-hover/row:text-muted-foreground/60'} hover:text-yellow-500`}
+          title={pinned ? 'Unpin from watch list' : 'Pin to watch list'}
+        >
+          <Pin className="h-2.5 w-2.5" />
+        </button>
+      )}
     </div>
   )
 }
@@ -34,11 +43,11 @@ function CollapsibleRow({ label, summary, children }: { label: string; summary: 
   )
 }
 
-function DataNode({ label, value, depth }: { label: string; value: unknown; depth: number }) {
-  if (value === null || value === undefined) return <Row label={label} value="—" />
+function DataNode({ label, value, depth, onPin, pinned }: { label: string; value: unknown; depth: number; onPin?: () => void; pinned?: boolean }) {
+  if (value === null || value === undefined) return <Row label={label} value="—" onPin={onPin} pinned={pinned} />
 
   if (Array.isArray(value)) {
-    if (depth >= MAX_DEPTH) return <Row label={label} value={`[${value.length} items]`} />
+    if (depth >= MAX_DEPTH) return <Row label={label} value={`[${value.length} items]`} onPin={onPin} pinned={pinned} />
     return (
       <CollapsibleRow label={label} summary={`[${value.length}]`}>
         {value.map((item, i) => <DataNode key={i} label={String(i)} value={item} depth={depth + 1} />)}
@@ -48,7 +57,7 @@ function DataNode({ label, value, depth }: { label: string; value: unknown; dept
 
   if (typeof value === 'object') {
     const keys = Object.keys(value)
-    if (depth >= MAX_DEPTH) return <Row label={label} value={`{${keys.length} keys}`} />
+    if (depth >= MAX_DEPTH) return <Row label={label} value={`{${keys.length} keys}`} onPin={onPin} pinned={pinned} />
     return (
       <CollapsibleRow label={label} summary={`{${keys.length}}`}>
         {keys.map((k) => <DataNode key={k} label={k} value={(value as Record<string, unknown>)[k]} depth={depth + 1} />)}
@@ -56,10 +65,17 @@ function DataNode({ label, value, depth }: { label: string; value: unknown; dept
     )
   }
 
-  return <Row label={label} value={formatScalar(value)} />
+  return <Row label={label} value={formatScalar(value)} onPin={onPin} pinned={pinned} />
 }
 
-export function UserDataView({ data }: { data: unknown }) {
+interface UserDataViewProps {
+  data: unknown
+  entityId?: string
+  onPinField?: (field: string) => void
+  isFieldPinned?: (field: string) => boolean
+}
+
+export function UserDataView({ data, entityId, onPinField, isFieldPinned }: UserDataViewProps) {
   if (data === null || data === undefined) return null
   if (typeof data !== 'object') return <Row label="value" value={formatScalar(data)} />
 
@@ -69,7 +85,16 @@ export function UserDataView({ data }: { data: unknown }) {
 
   return (
     <div className="space-y-0">
-      {entries.map(([k, v]) => <DataNode key={k} label={k} value={v} depth={0} />)}
+      {entries.map(([k, v]) => (
+        <DataNode
+          key={k}
+          label={k}
+          value={v}
+          depth={0}
+          onPin={onPinField && entityId ? () => onPinField(k) : undefined}
+          pinned={isFieldPinned ? isFieldPinned(k) : undefined}
+        />
+      ))}
     </div>
   )
 }

--- a/client-next/src/ui/panels/EntityDebugPanel.tsx
+++ b/client-next/src/ui/panels/EntityDebugPanel.tsx
@@ -49,6 +49,9 @@ function LedSwatches({ colors }: { colors: string[] }) {
 }
 
 function EntityContent({ entity, computed }: { entity: AnyEntity; computed: Record<string, unknown> | undefined }) {
+  const { pinField, unpinField, isFieldPinned } = useExperimentStore(
+    useShallow((s) => ({ pinField: s.pinField, unpinField: s.unpinField, isFieldPinned: s.isFieldPinned }))
+  )
   if (!('position' in entity)) return <p className="text-xs text-muted-foreground">No spatial data</p>
 
   const hasLeds = 'leds' in entity && Array.isArray(entity.leds) && entity.leds.length > 0
@@ -106,7 +109,15 @@ function EntityContent({ entity, computed }: { entity: AnyEntity; computed: Reco
       {entity.user_data !== undefined && (
         <Sect title="User Data" defaultOpen={false}>
           <div className="pl-2">
-            <UserDataView data={entity.user_data} />
+            <UserDataView
+              data={entity.user_data}
+              entityId={entity.id}
+              onPinField={(field) => {
+                if (isFieldPinned(entity.id, field)) unpinField(entity.id, field)
+                else pinField(entity.id, field)
+              }}
+              isFieldPinned={(field) => isFieldPinned(entity.id, field)}
+            />
           </div>
         </Sect>
       )}

--- a/client-next/src/ui/panels/WatchListPanel.tsx
+++ b/client-next/src/ui/panels/WatchListPanel.tsx
@@ -1,0 +1,47 @@
+import { useShallow } from 'zustand/shallow'
+import { useExperimentStore } from '@/stores/experimentStore'
+import { FloatingPanel } from '../FloatingPanel'
+import { Pin } from 'lucide-react'
+
+function formatValue(v: unknown): string {
+  if (v === null || v === undefined) return '—'
+  if (typeof v === 'number') return Number.isInteger(v) ? String(v) : v.toFixed(4)
+  if (typeof v === 'boolean') return v ? '✓' : '✗'
+  if (typeof v === 'string') return v
+  return JSON.stringify(v)
+}
+
+export function WatchListPanel() {
+  const { pinnedFields, entities, unpinField } = useExperimentStore(
+    useShallow((s) => ({ pinnedFields: s.pinnedFields, entities: s.entities, unpinField: s.unpinField }))
+  )
+
+  if (pinnedFields.length === 0) return null
+
+  return (
+    <FloatingPanel id="watch-list" title="Watch List" defaultPosition={{ pin: 'top-left' }}>
+      <div className="w-64 max-h-[50vh] overflow-auto p-2 space-y-0">
+        {pinnedFields.map(({ entityId, field }) => {
+          const entity = entities.get(entityId)
+          const ud = entity && 'user_data' in entity ? (entity as any).user_data as Record<string, unknown> | undefined : undefined
+          const value = ud?.[field]
+          return (
+            <div key={`${entityId}.${field}`} className="flex items-baseline py-px group/row">
+              <span className="text-[10px] text-muted-foreground truncate mr-1">{entityId}</span>
+              <span className="text-[10px] text-muted-foreground/60">.</span>
+              <span className="text-[10px] text-muted-foreground">{field}</span>
+              <span className="text-[10px] font-mono text-right ml-auto">{formatValue(value)}</span>
+              <button
+                onClick={() => unpinField(entityId, field)}
+                className="ml-1 shrink-0 text-yellow-500 hover:text-destructive"
+                title="Unpin"
+              >
+                <Pin className="h-2.5 w-2.5" />
+              </button>
+            </div>
+          )
+        })}
+      </div>
+    </FloatingPanel>
+  )
+}

--- a/docs/proposals/PN-028-user-data-pinning.md
+++ b/docs/proposals/PN-028-user-data-pinning.md
@@ -1,0 +1,154 @@
+# Proposal: User Data Field Pinning / Watch List
+
+Created: 2026-04-26
+Baseline Commit: `5cc38ae` (`master`)
+GitHub Issue: #57
+
+## Status: 🔵 IMPLEMENTATION
+<!-- 📋 INVESTIGATION → 🔍 CRITIQUE → 🟡 DESIGN → 🔍 CRITIQUE → 🔵 IMPLEMENTATION → 🟣 VERIFICATION → ✅ COMPLETE / 🔴 ABANDONED -->
+
+## Goal
+
+Let users pin specific `user_data` fields to a persistent watch list that stays visible regardless of which entity is selected. Currently, user_data is only visible in the entity debug panel for the selected entity — switching entities loses sight of the previous one's data.
+
+## Scope Boundary
+
+**In scope:**
+- Pin/unpin individual user_data fields from the entity debug panel
+- A "Watch List" panel showing pinned fields across entities, updating live
+- Persist pinned fields in local storage across sessions
+
+**Out of scope:**
+- ❌ Per-entity-type filtering (server-side, PN-026 territory)
+- ❌ Editing user_data values from the client
+- ❌ Charting or graphing pinned values over time
+- ❌ C++ changes — this is client-only
+
+## Current State
+
+**What exists:**
+- `EntityDebugPanel` (`client-next/src/ui/panels/EntityDebugPanel.tsx`) shows user_data for the selected entity via `UserDataView`
+- `ExperimentDataPanel` shows global (experiment-level) user_data
+- Entity store tracks `selectedEntityId` and `entities` map with all entity data including `user_data`
+- `debugPinnedIds` set exists in the store for pinning entity IDs (debug panel feature)
+
+**What's missing:**
+- No way to pin individual user_data *fields* (e.g., "always show `counter` for `fb_0`")
+- No watch list panel that persists across entity selection changes
+- No local storage persistence for pinned fields
+
+## Affected Components
+
+- [ ] C++ plugin (`src/`)
+- [ ] Legacy client (`client/`)
+- [x] Next client (`client-next/`)
+- [ ] Protocol / message format
+- [ ] Build system / CMake
+- [ ] Documentation
+
+## Design
+
+### Approach
+
+Add a "pin" button next to each user_data field in the entity debug panel. Pinned fields are stored as `{entityId, fieldPath}` tuples. A new "Watch List" floating panel renders all pinned fields by reading from the entities map each tick.
+
+### Key Decisions
+
+1. **Pin at field level, not entity level** — pinning an entity's `counter` field is more useful than pinning all of an entity's data
+2. **Watch list is a separate panel** — keeps the debug panel focused on the selected entity
+3. **Local storage persistence** — pinned fields survive page reload
+4. **Top-level keys only** — consistent with PN-026's filtering approach
+
+### Pseudocode / Steps
+
+```
+User clicks pin icon next to "counter" field on entity "fb_0":
+  → store adds {entityId: "fb_0", field: "counter"} to pinnedFields set
+  → localStorage updated
+
+Watch List panel renders:
+  for each {entityId, field} in pinnedFields:
+    value = entities.get(entityId)?.user_data?.[field]
+    render row: "fb_0.counter = 42"
+
+User clicks unpin:
+  → remove from pinnedFields set
+  → localStorage updated
+```
+
+## Key File References
+
+| File | Current State | Change |
+|---|---|---|
+| `client-next/src/ui/panels/EntityDebugPanel.tsx` | Shows user_data via UserDataView | Add pin button per field |
+| `client-next/src/ui/UserDataView.tsx` | Renders user_data key/value rows | Add pin icon per row |
+| `client-next/src/stores/experimentStore.ts` | Has entities map, selectedEntityId | Add pinnedFields state |
+| `client-next/src/ui/panels/WatchListPanel.tsx` | Does not exist | New panel for pinned fields |
+
+## Assumptions
+
+- [x] user_data fields are top-level JSON keys (nested pinning not needed initially)
+- [ ] UserDataView component renders individual rows that can accept an action button
+- [ ] FloatingPanel infrastructure supports adding new panels without layout changes
+
+## Dependencies
+
+- **Requires**: None
+- **Enhanced by**: PN-025 (Smart User Data Display)
+- **Blocks**: None
+
+## Done When
+
+- [ ] Pin icon appears next to each user_data field in entity debug panel
+- [ ] Clicking pin adds field to watch list
+- [ ] Watch List panel shows all pinned fields with live values
+- [ ] Pinned fields persist across page reload via localStorage
+- [ ] Unpinning removes from watch list
+- [ ] Pinning a field from a non-existent entity shows "—" gracefully
+
+## Verification Strategy
+
+### Success Criteria
+- Pin `counter` on `fb_0`, select `fb_1`, watch list still shows `fb_0.counter` updating
+
+### Regression Checks
+- Entity debug panel still works normally without any pins
+- ExperimentDataPanel unaffected
+
+### Test Plan
+| Test | Type | Procedure | Expected Result |
+|------|------|-----------|-----------------|
+| Pin field | Functional | Click pin on user_data field | Appears in watch list |
+| Unpin field | Functional | Click unpin | Removed from watch list |
+| Persist | Functional | Pin field, reload page | Pin restored |
+| Missing entity | Functional | Pin field, entity removed | Shows "—" |
+| Build | Automated | npm run build | Clean compile |
+
+### Acceptance Threshold
+- All functional tests pass, build clean
+
+## Effort Estimate
+
+**Time:** 2-3 FTE-hours
+
+**Change Footprint:**
+
+| Metric | Estimate |
+|--------|----------|
+| Files created | 1 |
+| Files modified | 3 |
+| Lines added/changed | ~120 |
+| Complexity | Low — client-only state + UI |
+
+## Related Proposals
+
+| Idea | Discovered During | Status |
+|------|------------------|--------|
+| Per-entity-type filtering | PN-026 | FUTURE.md |
+| Chart pinned values over time | PN-028 investigation | FUTURE.md candidate |
+
+## Changelog
+
+| Date | Change | Phase |
+|------|--------|-------|
+| 2026-04-26 | Initial draft | 📋 INVESTIGATION |


### PR DESCRIPTION
Pin specific `user_data` fields to a persistent watch list that stays visible regardless of which entity is selected.

## Changes
- Add `pinnedFields` state to experiment store with `localStorage` persistence
- Add pin/unpin toggle (📌 icon) to `UserDataView` rows for top-level fields
- Wire pin callbacks through `EntityDebugPanel`'s user data section
- New `WatchListPanel` floating panel shows all pinned fields with live values
- Panel auto-hides when no fields are pinned

## Testing
- Client builds clean (`vite build` succeeds)
- No new TS errors introduced (pre-existing errors unchanged)

Closes #57