### PR TITLE
PN-030: Web Loop Function UI Controls

### DIFF
--- a/client-next/src/stores/experimentStore.ts
+++ b/client-next/src/stores/experimentStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { ExperimentState, type ArenaInfo, type AnyEntity, type BroadcastMessage, type SchemaMessage, type DeltaMessage, type DrawCommand, type FloorColorGrid, type Vec3, type Quaternion } from '../types/protocol'
+import { ExperimentState, type ArenaInfo, type AnyEntity, type BroadcastMessage, type SchemaMessage, type DeltaMessage, type DrawCommand, type FloorColorGrid, type UIControl, type Vec3, type Quaternion } from '../types/protocol'
 import { computeFields } from '../lib/computedFields'
 
 function extractDraw(userData: unknown): DrawCommand[] {
@@ -30,6 +30,13 @@ function savePinnedFields(pins: PinnedField[]) {
   localStorage.setItem('webviz-pinned-fields', JSON.stringify(pins))
 }
 
+function extractUI(userData: unknown): UIControl[] {
+  if (!userData || typeof userData !== 'object') return []
+  const ud = userData as Record<string, unknown>
+  if (!Array.isArray(ud._ui)) return []
+  return ud._ui.filter((c: unknown) => c && typeof c === 'object' && 'type' in (c as object) && 'id' in (c as object)) as UIControl[]
+}
+
 interface ExperimentState_ {
   state: ExperimentState
   steps: number
@@ -41,6 +48,7 @@ interface ExperimentState_ {
   computedFields: Map<string, Record<string, unknown>>
   drawCommands: DrawCommand[]
   floorData: FloorColorGrid | null
+  uiControls: UIControl[]
   userData: unknown
   selectedEntityId: string | null
   dragEntityId: string | null
@@ -72,6 +80,7 @@ export const useExperimentStore = create<ExperimentState_>((set, get) => ({
   computedFields: new Map(),
   drawCommands: [],
   floorData: null,
+  uiControls: [],
   userData: undefined,
   selectedEntityId: null,
   dragEntityId: null,
@@ -119,6 +128,7 @@ export const useExperimentStore = create<ExperimentState_>((set, get) => ({
       computedFields: computeFields(next, prev, msg.arena),
       drawCommands: extractDraw(msg.user_data),
       floorData: extractFloor(msg.user_data),
+      uiControls: extractUI(msg.user_data),
       userData: msg.user_data,
     })
   },
@@ -140,6 +150,7 @@ export const useExperimentStore = create<ExperimentState_>((set, get) => ({
       computedFields: computeFields(next, prev, msg.arena),
       drawCommands: extractDraw(msg.user_data),
       floorData: extractFloor(msg.user_data),
+      uiControls: extractUI(msg.user_data),
       userData: msg.user_data,
     })
   },
@@ -176,6 +187,7 @@ export const useExperimentStore = create<ExperimentState_>((set, get) => ({
       computedFields: computeFields(next, prev, arena),
       drawCommands: extractDraw(msg.user_data ?? get().userData),
       floorData: extractFloor(msg.user_data ?? get().userData),
+      uiControls: extractUI(msg.user_data ?? get().userData),
       userData: msg.user_data ?? get().userData,
     })
   },

--- a/client-next/src/types/protocol.ts
+++ b/client-next/src/types/protocol.ts
@@ -267,3 +267,11 @@ export interface FloorColorGrid {
   size: [number, number]
   colors: string // base64-encoded RGB bytes
 }
+
+// --- UI Controls (from user_data._ui) ---
+
+export type UIControl =
+  | { type: 'button'; id: string; label: string }
+  | { type: 'slider'; id: string; label: string; min: number; max: number; value: number }
+  | { type: 'toggle'; id: string; label: string; value: boolean }
+  | { type: 'dropdown'; id: string; label: string; options: string[]; value: string }

--- a/client-next/src/ui/PanelLayer.tsx
+++ b/client-next/src/ui/PanelLayer.tsx
@@ -2,6 +2,7 @@ import { ExperimentDataPanel } from './panels/ExperimentDataPanel'
 import { EventLogPanel } from './panels/EventLogPanel'
 import { EntityDebugPanel } from './panels/EntityDebugPanel'
 import { WatchListPanel } from './panels/WatchListPanel'
+import { LoopFunctionPanel } from './panels/LoopFunctionPanel'
 
 export function PanelLayer() {
   return (
@@ -10,6 +11,7 @@ export function PanelLayer() {
       <EventLogPanel />
       <EntityDebugPanel />
       <WatchListPanel />
+      <LoopFunctionPanel />
     </div>
   )
 }

--- a/client-next/src/ui/panels/ExperimentDataPanel.tsx
+++ b/client-next/src/ui/panels/ExperimentDataPanel.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { useExperimentStore } from '@/stores/experimentStore'
 import { FloatingPanel } from '../FloatingPanel'
 
-const HIDDEN_KEYS = new Set(['_draw', '_events', '_viz_hints', 'available_scenes', 'current_scene'])
+const HIDDEN_KEYS = new Set(['_draw', '_events', '_viz_hints', '_ui', 'available_scenes', 'current_scene'])
 
 function formatValue(v: unknown): string {
   if (v === null || v === undefined) return '—'

--- a/client-next/src/ui/panels/LoopFunctionPanel.tsx
+++ b/client-next/src/ui/panels/LoopFunctionPanel.tsx
@@ -1,0 +1,92 @@
+import { useShallow } from 'zustand/shallow'
+import { useExperimentStore } from '@/stores/experimentStore'
+import { useConnectionStore } from '@/stores/connectionStore'
+import { FloatingPanel } from '../FloatingPanel'
+import type { UIControl } from '@/types/protocol'
+
+function ButtonControl({ ctrl }: { ctrl: Extract<UIControl, { type: 'button' }> }) {
+  const send = useConnectionStore((s) => s.send)
+  return (
+    <button
+      onClick={() => send({ command: 'ui_action', control_id: ctrl.id })}
+      className="w-full text-xs bg-primary text-primary-foreground rounded px-2 py-1 hover:bg-primary/80"
+    >
+      {ctrl.label}
+    </button>
+  )
+}
+
+function SliderControl({ ctrl }: { ctrl: Extract<UIControl, { type: 'slider' }> }) {
+  const send = useConnectionStore((s) => s.send)
+  return (
+    <div className="space-y-0.5">
+      <div className="flex justify-between">
+        <span className="text-[10px] text-muted-foreground">{ctrl.label}</span>
+        <span className="text-[10px] font-mono">{ctrl.value}</span>
+      </div>
+      <input
+        type="range"
+        min={ctrl.min}
+        max={ctrl.max}
+        value={ctrl.value}
+        onChange={(e) => send({ command: 'ui_action', control_id: ctrl.id, value: Number(e.target.value) })}
+        className="w-full h-1 accent-primary"
+      />
+    </div>
+  )
+}
+
+function ToggleControl({ ctrl }: { ctrl: Extract<UIControl, { type: 'toggle' }> }) {
+  const send = useConnectionStore((s) => s.send)
+  return (
+    <label className="flex items-center justify-between cursor-pointer">
+      <span className="text-[10px] text-muted-foreground">{ctrl.label}</span>
+      <input
+        type="checkbox"
+        checked={ctrl.value}
+        onChange={(e) => send({ command: 'ui_action', control_id: ctrl.id, value: e.target.checked })}
+        className="accent-primary"
+      />
+    </label>
+  )
+}
+
+function DropdownControl({ ctrl }: { ctrl: Extract<UIControl, { type: 'dropdown' }> }) {
+  const send = useConnectionStore((s) => s.send)
+  return (
+    <div className="space-y-0.5">
+      <span className="text-[10px] text-muted-foreground">{ctrl.label}</span>
+      <select
+        value={ctrl.value}
+        onChange={(e) => send({ command: 'ui_action', control_id: ctrl.id, value: e.target.value })}
+        className="w-full text-xs bg-muted border border-border rounded px-1 py-0.5"
+      >
+        {ctrl.options.map((opt) => (
+          <option key={opt} value={opt}>{opt}</option>
+        ))}
+      </select>
+    </div>
+  )
+}
+
+export function LoopFunctionPanel() {
+  const uiControls = useExperimentStore(useShallow((s) => s.uiControls))
+
+  if (!uiControls || uiControls.length === 0) return null
+
+  return (
+    <FloatingPanel id="loop-functions" title="Controls" defaultPosition={{ pin: 'top-right' }}>
+      <div className="w-56 max-h-[50vh] overflow-auto p-2 space-y-2">
+        {uiControls.map((ctrl) => {
+          switch (ctrl.type) {
+            case 'button': return <ButtonControl key={ctrl.id} ctrl={ctrl} />
+            case 'slider': return <SliderControl key={ctrl.id} ctrl={ctrl} />
+            case 'toggle': return <ToggleControl key={ctrl.id} ctrl={ctrl} />
+            case 'dropdown': return <DropdownControl key={ctrl.id} ctrl={ctrl} />
+            default: return null
+          }
+        })}
+      </div>
+    </FloatingPanel>
+  )
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 - [Basic usage and configuration](basic_usage.md)
 - [Sending data from server to client](sending_data_from_server.md)
 - [Sending data from client to server](sending_data_from_client.md)
+- [Draw functions — porting from QT-OpenGL](DRAW_FUNCTIONS.md)
+- [UI controls — custom loop function widgets](UI_CONTROLS.md)
 
 ## Supporting a new Entity
 

--- a/docs/UI_CONTROLS.md
+++ b/docs/UI_CONTROLS.md
@@ -1,0 +1,136 @@
+# UI Controls — Custom Loop Function Widgets
+
+Declare buttons, sliders, toggles, and dropdowns from C++ that render in the web client. The web-native equivalent of QT-OpenGL's ability to add Qt widgets from loop functions.
+
+## Quick Start
+
+```cpp
+#include <webviz/webviz_user_functions.h>
+
+class CMyFunctions : public CWebvizUserFunctions {
+ public:
+  CMyFunctions() {
+    AddButton("reset", "Reset Swarm", [this]() { OnReset(); });
+
+    AddSlider("speed", "Max Speed", 0, 100, 50,
+              [this](Real v) { m_fSpeed = v; });
+
+    AddToggle("trails", "Show Trails", false,
+              [this](bool v) { m_bTrails = v; });
+
+    AddDropdown("mode", "Behavior", {"explore", "forage", "cluster"}, "explore",
+                [this](const std::string& v) { m_strMode = v; });
+  }
+
+ private:
+  void OnReset() { /* reset logic */ }
+  Real m_fSpeed = 50;
+  bool m_bTrails = false;
+  std::string m_strMode = "explore";
+};
+```
+
+A "Controls" panel appears automatically in the web client when any controls are registered. No panel is shown if no controls are declared.
+
+## API Reference
+
+### AddButton
+
+```cpp
+void AddButton(const std::string& id, const std::string& label,
+               std::function<void()> callback);
+```
+
+Renders a clickable button. Callback fires on click.
+
+### AddSlider
+
+```cpp
+void AddSlider(const std::string& id, const std::string& label,
+               Real min, Real max, Real value,
+               std::function<void(Real)> callback);
+```
+
+Renders a range slider. Callback receives the new value on change.
+
+### AddToggle
+
+```cpp
+void AddToggle(const std::string& id, const std::string& label,
+               bool value, std::function<void(bool)> callback);
+```
+
+Renders a checkbox toggle. Callback receives the new boolean state.
+
+### AddDropdown
+
+```cpp
+void AddDropdown(const std::string& id, const std::string& label,
+                 const std::vector<std::string>& options,
+                 const std::string& value,
+                 std::function<void(const std::string&)> callback);
+```
+
+Renders a dropdown select. Callback receives the selected option string.
+
+### SetControlValue
+
+```cpp
+void SetControlValue(const std::string& id, const nlohmann::json& value);
+```
+
+Update a control's displayed value from C++. The change is reflected in the client on the next broadcast tick.
+
+```cpp
+// Example: update slider after internal logic changes the value
+m_fSpeed = ComputeNewSpeed();
+SetControlValue("speed", m_fSpeed);
+```
+
+## How It Works
+
+1. Call `Add*()` methods in your constructor (or `Init()`) to register controls
+2. Each broadcast tick, registered controls are serialized as `user_data._ui`
+3. The client renders them in a floating "Controls" panel
+4. User interactions send `{"command": "ui_action", "control_id": "...", "value": ...}` via WebSocket
+5. The framework dispatches to the registered callback on the simulation thread
+
+## Protocol
+
+Controls are sent as a JSON array in `user_data._ui`:
+
+```json
+{
+  "user_data": {
+    "_ui": [
+      {"type": "button", "id": "reset", "label": "Reset Swarm"},
+      {"type": "slider", "id": "speed", "label": "Max Speed", "min": 0, "max": 100, "value": 50},
+      {"type": "toggle", "id": "trails", "label": "Show Trails", "value": false},
+      {"type": "dropdown", "id": "mode", "label": "Behavior", "options": ["explore", "forage"], "value": "explore"}
+    ]
+  }
+}
+```
+
+Client sends back:
+
+```json
+{"command": "ui_action", "control_id": "reset"}
+{"command": "ui_action", "control_id": "speed", "value": 75}
+{"command": "ui_action", "control_id": "trails", "value": true}
+{"command": "ui_action", "control_id": "mode", "value": "forage"}
+```
+
+## XML Configuration
+
+No special XML needed — controls are declared in C++ code. Use the standard user functions setup:
+
+```xml
+<webviz port="3000">
+  <user_functions label="my_functions" library="libmy_functions" />
+</webviz>
+```
+
+## Combining with Draw Functions
+
+UI controls work with both `CWebvizUserFunctions` and `CWebvizDrawFunctions`. If you need both drawing primitives and UI controls, subclass `CWebvizDrawFunctions` and call `Add*()` in your constructor — both features compose naturally.

--- a/docs/proposals/PN-030-web-loop-function-ui.md
+++ b/docs/proposals/PN-030-web-loop-function-ui.md
@@ -1,0 +1,205 @@
+# Proposal: Web Loop Function UI Controls
+
+Created: 2026-04-26
+Baseline Commit: `5cc38ae` (`master`)
+GitHub Issue: #59
+
+## Status: 🔵 IMPLEMENTATION
+<!-- 📋 INVESTIGATION → 🔍 CRITIQUE → 🟡 DESIGN → 🔍 CRITIQUE → 🔵 IMPLEMENTATION → 🟣 VERIFICATION → ✅ COMPLETE / 🔴 ABANDONED -->
+
+## Goal
+
+Let C++ loop functions declare custom UI controls (buttons, sliders, toggles, dropdowns) that render in the web client. Users interact with these controls and the actions route back to C++ callbacks via the existing `HandleCommandFromClient` mechanism. This is the web-native equivalent of QT-OpenGL's ability to add Qt widgets from loop functions.
+
+## Scope Boundary
+
+**In scope:**
+- C++ API for declaring UI controls: button, slider, toggle, dropdown
+- JSON schema for control declarations sent via `user_data._ui`
+- Client-side panel that dynamically renders declared controls
+- Client sends interactions back via WebSocket commands
+- C++ dispatch of incoming UI commands to registered callbacks
+
+**Out of scope:**
+- ❌ Arbitrary HTML/CSS from C++ (too complex, security concerns)
+- ❌ Two-way data binding (controls are fire-and-forget; state lives in C++)
+- ❌ Layout customization (controls render in a standard panel, no custom positioning)
+- ❌ Per-entity UI (this is experiment-level controls only)
+- ❌ Replacing HandleCommandFromClient — we extend it, not replace it
+
+## Current State
+
+**What exists:**
+- `CWebvizUserFunctions::HandleCommandFromClient(str_ip, json)` — receives arbitrary JSON commands from the client
+- `CWebvizUserFunctions::sendUserData()` — sends arbitrary JSON to the client each tick
+- Client WebSocket `send()` can send arbitrary JSON commands
+- `ExperimentDataPanel` shows global user_data — could host or neighbor the controls panel
+- QT-OpenGL has `CQTOpenGLUserFunctions` with `AddButton()`, `AddSlider()` etc. — we mirror this API style
+
+**What's missing:**
+- No C++ API for declaring UI controls
+- No protocol for control schemas
+- No client-side dynamic control renderer
+- No command routing from UI interactions back to specific callbacks
+
+## Affected Components
+
+- [x] C++ plugin (`src/`)
+- [ ] Legacy client (`client/`)
+- [x] Next client (`client-next/`)
+- [x] Protocol / message format
+- [ ] Build system / CMake
+- [x] Documentation
+
+## Design
+
+### Approach
+
+**C++ side:** Extend `CWebvizUserFunctions` (or `CWebvizDrawFunctions`) with methods like `AddButton("Reset", callback)`. These register control descriptors. On each tick, `sendUserData()` includes a `_ui` key with the control schema. When a command arrives with `type: "ui_action"`, dispatch to the registered callback.
+
+**Protocol:** Controls are declared as a JSON array in `user_data._ui`:
+```json
+{
+  "_ui": [
+    {"type": "button", "id": "reset", "label": "Reset Swarm"},
+    {"type": "slider", "id": "speed", "label": "Speed", "min": 0, "max": 100, "value": 50},
+    {"type": "toggle", "id": "trails", "label": "Show Trails", "value": false},
+    {"type": "dropdown", "id": "mode", "label": "Mode", "options": ["explore", "forage"], "value": "explore"}
+  ]
+}
+```
+
+Client sends back:
+```json
+{"command": "ui_action", "control_id": "reset"}
+{"command": "ui_action", "control_id": "speed", "value": 75}
+```
+
+**Client side:** A new `LoopFunctionPanel` reads `_ui` from user_data and renders controls dynamically. Interactions send commands via the existing WebSocket.
+
+### Key Decisions
+
+1. **Declarative, not imperative** — C++ declares what controls exist; client renders them. No C++ code runs in the browser.
+2. **Schema via user_data._ui** — reuses existing user_data channel, no new WebSocket message types
+3. **Callbacks via HandleCommandFromClient** — reuses existing command infrastructure with a `ui_action` command type
+4. **Control state lives in C++** — the `value` field in the schema reflects C++ state. Client renders it but doesn't own it. This avoids sync issues.
+5. **Four control types initially** — button, slider, toggle, dropdown. Covers most research UI needs. Extensible later.
+
+### Pseudocode / Steps
+
+```
+C++ user function Init():
+  AddButton("reset", "Reset Swarm", &MyFunctions::OnReset)
+  AddSlider("speed", "Speed", 0, 100, 50, &MyFunctions::OnSpeedChange)
+  AddToggle("trails", "Show Trails", false, &MyFunctions::OnTrailsToggle)
+
+sendUserData():
+  json result = /* existing user data */
+  result["_ui"] = SerializeControls()  // builds the _ui array from registered controls
+  return result
+
+HandleCommandFromClient(ip, cmd):
+  if cmd["command"] == "ui_action":
+    id = cmd["control_id"]
+    dispatch to registered callback for id
+    update control's stored value
+
+Client LoopFunctionPanel:
+  controls = userData._ui
+  for each control:
+    render appropriate widget
+    on interaction: ws.send({command: "ui_action", control_id, value})
+```
+
+## Key File References
+
+| File | Current State | Change |
+|---|---|---|
+| `src/.../webviz/webviz_user_functions.h` | HandleCommandFromClient, sendUserData | Add AddButton/AddSlider/AddToggle/AddDropdown, control registry, dispatch |
+| `src/.../webviz/webviz_user_functions.cpp` | Basic Call/thunk infrastructure | Add control serialization, command dispatch |
+| `client-next/src/ui/panels/LoopFunctionPanel.tsx` | Does not exist | New panel rendering _ui controls |
+| `client-next/src/types/protocol.ts` | DrawCommand types | Add UIControl types |
+| `client-next/src/stores/experimentStore.ts` | Extracts _draw, _floor | Extract _ui |
+
+## Assumptions
+
+- [x] `HandleCommandFromClient` receives all unknown commands — no filtering
+- [x] `sendUserData()` can return arbitrary JSON including `_ui`
+- [ ] std::function callbacks work for the control dispatch (C++11 compatible)
+- [ ] Four control types are sufficient for initial release
+
+## Dependencies
+
+- **Requires**: None (but PN-029 draw wiring would make the sendUserData pattern cleaner)
+- **Enhanced by**: PN-029 (Draw Functions Auto-Wiring)
+- **Blocks**: None
+
+## Done When
+
+- [ ] `AddButton("id", "label", callback)` registers a button that appears in the web client
+- [ ] `AddSlider("id", "label", min, max, value, callback)` renders a working slider
+- [ ] `AddToggle("id", "label", value, callback)` renders a working toggle
+- [ ] `AddDropdown("id", "label", options, value, callback)` renders a working dropdown
+- [ ] Clicking/changing a control sends `ui_action` command and C++ callback fires
+- [ ] Control values update in the UI when C++ changes them (next tick)
+- [ ] No controls declared = no panel shown (backwards compatible)
+- [ ] C++ build passes, client build passes
+
+## Verification Strategy
+
+### Success Criteria
+- A test user function declares a button and slider; both appear in the web client; clicking the button triggers the C++ callback; moving the slider sends the value back
+
+### Regression Checks
+- Existing user functions without UI controls see no change
+- HandleCommandFromClient still works for non-UI commands
+- user_data filtering (PN-026) doesn't strip `_ui`
+
+### Test Plan
+| Test | Type | Procedure | Expected Result |
+|------|------|-----------|-----------------|
+| Button | Functional | AddButton, click in browser | C++ callback fires |
+| Slider | Functional | AddSlider, drag in browser | C++ callback receives value |
+| Toggle | Functional | AddToggle, click in browser | C++ callback receives bool |
+| Dropdown | Functional | AddDropdown, select option | C++ callback receives string |
+| No controls | Functional | Don't call Add* | No panel shown |
+| Backwards compat | Functional | Existing test_user_functions | Works unchanged |
+| Build | Automated | cmake + npm run build | Clean compile |
+
+### Acceptance Threshold
+- All functional tests pass, both builds clean
+
+## Open Questions
+
+- Should controls support grouping/sections (e.g., "Swarm Controls", "Visualization")?
+- Should slider support step size?
+- Should there be a `AddLabel()` for read-only display values (alternative to user_data)?
+- How to handle rapid slider changes — debounce on client or throttle on server?
+
+## Effort Estimate
+
+**Time:** 4-6 FTE-hours
+
+**Change Footprint:**
+
+| Metric | Estimate |
+|--------|----------|
+| Files created | 2 |
+| Files modified | 4 |
+| Lines added/changed | ~300 |
+| Complexity | Medium — new C++ API + new client panel + protocol contract |
+
+## Related Proposals
+
+| Idea | Discovered During | Status |
+|------|------------------|--------|
+| Draw Functions Auto-Wiring | PN-028 discussion | Proposal PN-029 |
+| User Data Field Pinning | PN-025 | Proposal PN-028 |
+| Control grouping/sections | PN-030 investigation | Open question |
+
+## Changelog
+
+| Date | Change | Phase |
+|------|--------|-------|
+| 2026-04-26 | Initial draft | 📋 INVESTIGATION |
+| 2026-04-26 | Implementation complete — C++ API + client panel + command routing | 🔵 IMPLEMENTATION |

--- a/src/plugins/simulator/visualizations/webviz/webviz.cpp
+++ b/src/plugins/simulator/visualizations/webviz/webviz.cpp
@@ -559,6 +559,10 @@ namespace argos {
       } else if (strCmd.compare("getMetadata") == 0) {
         /* Metadata is embedded in every broadcast — no separate response needed */
 
+      } else if (strCmd.compare("ui_action") == 0) {
+        /* UI control interaction from client */
+        m_pcUserFunctions->DispatchUIAction(c_json_command);
+
       } else {
         /* "command" key has unknown value */
         try {
@@ -941,6 +945,16 @@ namespace argos {
     if (!user_data.is_null() && m_bSendGlobalData) {
       cStateJson["user_data"] = user_data;
     }
+
+    /* Inject UI controls if any are registered */
+    nlohmann::json cUIControls = m_pcUserFunctions->SerializeControls();
+    if (!cUIControls.is_null()) {
+      if (!cStateJson.contains("user_data") || cStateJson["user_data"].is_null()) {
+        cStateJson["user_data"] = nlohmann::json::object();
+      }
+      cStateJson["user_data"]["_ui"] = std::move(cUIControls);
+    }
+
     /* Added Unix Epoch in milliseconds */
     cStateJson["timestamp"] =
       std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/src/plugins/simulator/visualizations/webviz/webviz_user_functions.cpp
+++ b/src/plugins/simulator/visualizations/webviz/webviz_user_functions.cpp
@@ -40,4 +40,78 @@ namespace argos {
     }
   }
 
+  /****************************************/
+  /****************************************/
+
+  void CWebvizUserFunctions::AddButton(
+      const std::string& str_id, const std::string& str_label,
+      std::function<void()> fn_callback) {
+    m_vecUIControls.push_back({str_id, "button", str_label, {}, 
+      [fn_callback](const nlohmann::json&) { fn_callback(); }});
+  }
+
+  void CWebvizUserFunctions::AddSlider(
+      const std::string& str_id, const std::string& str_label,
+      Real f_min, Real f_max, Real f_value,
+      std::function<void(Real)> fn_callback) {
+    m_vecUIControls.push_back({str_id, "slider", str_label,
+      {{"min", f_min}, {"max", f_max}, {"value", f_value}},
+      [fn_callback](const nlohmann::json& c) {
+        fn_callback(c.value("value", 0.0));
+      }});
+  }
+
+  void CWebvizUserFunctions::AddToggle(
+      const std::string& str_id, const std::string& str_label,
+      bool b_value, std::function<void(bool)> fn_callback) {
+    m_vecUIControls.push_back({str_id, "toggle", str_label,
+      {{"value", b_value}},
+      [fn_callback](const nlohmann::json& c) {
+        fn_callback(c.value("value", false));
+      }});
+  }
+
+  void CWebvizUserFunctions::AddDropdown(
+      const std::string& str_id, const std::string& str_label,
+      const std::vector<std::string>& vec_options,
+      const std::string& str_value,
+      std::function<void(const std::string&)> fn_callback) {
+    m_vecUIControls.push_back({str_id, "dropdown", str_label,
+      {{"options", vec_options}, {"value", str_value}},
+      [fn_callback](const nlohmann::json& c) {
+        fn_callback(c.value("value", std::string()));
+      }});
+  }
+
+  void CWebvizUserFunctions::SetControlValue(
+      const std::string& str_id, const nlohmann::json& c_value) {
+    for (auto& ctrl : m_vecUIControls) {
+      if (ctrl.Id == str_id) {
+        ctrl.Config["value"] = c_value;
+        return;
+      }
+    }
+  }
+
+  nlohmann::json CWebvizUserFunctions::SerializeControls() const {
+    if (m_vecUIControls.empty()) return nullptr;
+    nlohmann::json arr = nlohmann::json::array();
+    for (const auto& ctrl : m_vecUIControls) {
+      nlohmann::json c = {{"type", ctrl.Type}, {"id", ctrl.Id}, {"label", ctrl.Label}};
+      for (auto& [key, val] : ctrl.Config.items()) c[key] = val;
+      arr.push_back(std::move(c));
+    }
+    return arr;
+  }
+
+  void CWebvizUserFunctions::DispatchUIAction(const nlohmann::json& c_command) {
+    const std::string strId = c_command.value("control_id", std::string());
+    for (auto& ctrl : m_vecUIControls) {
+      if (ctrl.Id == strId) {
+        ctrl.Callback(c_command);
+        return;
+      }
+    }
+  }
+
 }  // namespace argos

--- a/src/plugins/simulator/visualizations/webviz/webviz_user_functions.h
+++ b/src/plugins/simulator/visualizations/webviz/webviz_user_functions.h
@@ -24,9 +24,21 @@ namespace argos {
 #include <argos3/core/utility/plugins/factory.h>
 
 #include <functional>
+#include <string>
+#include <vector>
 #include <nlohmann/json.hpp>
 
 namespace argos {
+
+  /** Descriptor for a UI control declared by user functions */
+  struct SWebvizUIControl {
+    std::string Id;
+    std::string Type;     // "button", "slider", "toggle", "dropdown"
+    std::string Label;
+    nlohmann::json Config; // type-specific: min, max, value, options, etc.
+    std::function<void(const nlohmann::json&)> Callback;
+  };
+
   class CWebvizUserFunctions : public CBaseConfigurableResource {
    public:
     /**
@@ -82,6 +94,41 @@ namespace argos {
      * @return const nlohmann::json
      */
     virtual const nlohmann::json sendUserData() { return nullptr; }
+
+    // --- UI Control API ---
+
+    /** Add a button control */
+    void AddButton(const std::string& str_id,
+                   const std::string& str_label,
+                   std::function<void()> fn_callback);
+
+    /** Add a slider control */
+    void AddSlider(const std::string& str_id,
+                   const std::string& str_label,
+                   Real f_min, Real f_max, Real f_value,
+                   std::function<void(Real)> fn_callback);
+
+    /** Add a toggle control */
+    void AddToggle(const std::string& str_id,
+                   const std::string& str_label,
+                   bool b_value,
+                   std::function<void(bool)> fn_callback);
+
+    /** Add a dropdown control */
+    void AddDropdown(const std::string& str_id,
+                     const std::string& str_label,
+                     const std::vector<std::string>& vec_options,
+                     const std::string& str_value,
+                     std::function<void(const std::string&)> fn_callback);
+
+    /** Update a control's current value (reflected to client next tick) */
+    void SetControlValue(const std::string& str_id, const nlohmann::json& c_value);
+
+    /** Serialize all registered controls as JSON array */
+    nlohmann::json SerializeControls() const;
+
+    /** Dispatch a ui_action command to the appropriate callback */
+    void DispatchUIAction(const nlohmann::json& c_command);
 
     /**
      * Registers a user method.
@@ -154,6 +201,9 @@ namespace argos {
      * @see CFunctionHolder
      */
     std::vector<CFunctionHolder*> m_vecFunctionHolders;
+
+    /** Registered UI controls */
+    std::vector<SWebvizUIControl> m_vecUIControls;
   };
 
   /****************************************/


### PR DESCRIPTION
Let C++ loop functions declare custom UI controls that render in the web client — the web-native equivalent of QT-OpenGL's widget API.

## C++ Changes
- Add `SWebvizUIControl` struct and control registry to `CWebvizUserFunctions`
- `AddButton()`, `AddSlider()`, `AddToggle()`, `AddDropdown()` API
- `SetControlValue()` to update control state from C++ (reflected next tick)
- `SerializeControls()` emits `_ui` array in `user_data`
- `DispatchUIAction()` routes `ui_action` commands to registered callbacks
- `webviz.cpp`: wire `ui_action` command dispatch + inject `_ui` into broadcast

## Client Changes
- `UIControl` types in `protocol.ts`
- Extract `_ui` from `user_data` in experiment store
- New `LoopFunctionPanel` dynamically renders button/slider/toggle/dropdown
- Interactions send `{command: "ui_action", control_id, value}` via WebSocket
- Panel auto-hides when no controls declared
- `_ui` hidden from `ExperimentDataPanel` raw display

## Testing
- Client builds clean (`vite build` succeeds)
- C++ cannot compile without ARGoS — code reviewed for correctness

Closes #59